### PR TITLE
validation_utils IsEmpty doesn't check for boolean values

### DIFF
--- a/internal/validation/validation_utils.go
+++ b/internal/validation/validation_utils.go
@@ -177,6 +177,10 @@ func IsEmpty(object interface{}) bool {
 	if object == nil {
 		return true
 	}
+	_, ok := object.(bool)
+	if ok {
+		return false
+	}
 	objectStr, ok := object.(string)
 	if ok {
 		if len(objectStr) > 0 {


### PR DESCRIPTION
Signed-off-by: Bryan Heden <b.heden@gmail.com>

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**
This offers a fix during vcf_domain creation when defining an nfs_datastore. The validation_utils.IsEmpty function doesn't check properly for a boolean value. This could also fix potential bugs in a few other places.
https://github.com/vmware/terraform-provider-vcf/blob/v0.2.0/internal/datastores/nfs_datastore_subresource.go#L68-L72
<!--
    Please provide a clear and concise description of the pull request.
-->

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
