### PR TITLE
Fix domain update and expand E2E

### DIFF
--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -201,7 +201,7 @@ func resourceClusterCreate(ctx context.Context, data *schema.ResourceData, meta 
 
 	data.SetId(clusterId)
 
-	return nil
+	return resourceClusterRead(ctx, data, meta)
 }
 
 func resourceClusterRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -239,7 +239,7 @@ func resourceClusterUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		return diagnostics
 	}
 
-	return nil
+	return resourceClusterRead(ctx, data, meta)
 }
 
 func resourceClusterDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -206,22 +206,22 @@ func resourceDomainUpdate(ctx context.Context, data *schema.ResourceData, meta i
 
 	if data.HasChange("cluster") {
 		oldClustersValue, newClustersValue := data.GetChange("cluster")
-		oldClustersList := oldClustersValue.([]interface{})
 		newClustersList := newClustersValue.([]interface{})
+		oldClustersList := oldClustersValue.([]interface{})
 		if len(oldClustersList) == len(newClustersList) {
-			diags := handleClusterUpdateInDomain(ctx, oldClustersList, newClustersList, vcfClient)
+			diags := handleClusterUpdateInDomain(ctx, newClustersList, oldClustersList, vcfClient)
 			if diags != nil {
 				return diags
 			}
 		} else {
-			diags := handleClusterAddRemoveToDomain(ctx, data.Id(), oldClustersList, newClustersList, vcfClient)
+			diags := handleClusterAddRemoveToDomain(ctx, data.Id(), newClustersList, oldClustersList, vcfClient)
 			if diags != nil {
 				return diags
 			}
 		}
 	}
 
-	return nil
+	return resourceDomainRead(ctx, data, meta)
 }
 
 func handleClusterAddRemoveToDomain(ctx context.Context, domainId string, newClustersList, oldClustersList []interface{},
@@ -250,8 +250,8 @@ func handleClusterAddRemoveToDomain(ctx context.Context, domainId string, newClu
 	return nil
 }
 
-func handleClusterUpdateInDomain(ctx context.Context, oldClustersStateList []interface{},
-	newClustersStateList []interface{}, vcfClient *SddcManagerClient) diag.Diagnostics {
+func handleClusterUpdateInDomain(ctx context.Context, newClustersStateList, oldClustersStateList []interface{},
+	vcfClient *SddcManagerClient) diag.Diagnostics {
 	if len(oldClustersStateList) != len(newClustersStateList) {
 		return diag.FromErr(fmt.Errorf("expecting old and new cluster list to have the same length"))
 	}

--- a/internal/provider/resource_domain_test.go
+++ b/internal/provider/resource_domain_test.go
@@ -24,6 +24,7 @@ func TestAccResourceVcfDomain(t *testing.T) {
 		CheckDestroy:      testCheckVcfDomainDestroy,
 		Steps: []resource.TestStep{
 			{
+				// Initial config: 1 network pool, 3 commissioned hosts, Domain with cluster with those 3 hosts
 				Config: testAccVcfDomainConfig(
 					testGenerateCommissionHostConfigs(
 						3,
@@ -184,6 +185,117 @@ func TestAccResourceVcfDomain(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.host.3.id"),
 				),
 			},
+			{
+				//remove  additional host in the second cluster in the domain
+				Config: testAccVcfDomainConfig(
+					testGenerateCommissionHostConfigs(
+						7,
+						os.Getenv(constants.VcfTestHost2Fqdn),
+						os.Getenv(constants.VcfTestHost2Pass),
+						os.Getenv(constants.VcfTestHost3Fqdn),
+						os.Getenv(constants.VcfTestHost3Pass),
+						os.Getenv(constants.VcfTestHost4Fqdn),
+						os.Getenv(constants.VcfTestHost4Pass),
+						os.Getenv(constants.VcfTestHost5Fqdn),
+						os.Getenv(constants.VcfTestHost5Pass),
+						os.Getenv(constants.VcfTestHost6Fqdn),
+						os.Getenv(constants.VcfTestHost6Pass),
+						os.Getenv(constants.VcfTestHost7Fqdn),
+						os.Getenv(constants.VcfTestHost7Pass),
+						os.Getenv(constants.VcfTestHost8Fqdn),
+						os.Getenv(constants.VcfTestHost8Pass)),
+					os.Getenv(constants.VcfTestNsxLicenseKey),
+					testAccVcfClusterInDomainConfig(
+						"sfo-w01-cl01",
+						testGenerateHostsInClusterInDomainConfig(
+							os.Getenv(constants.VcfTestEsxiLicenseKey),
+							"sfo-w01-cl01",
+							"host1", "host2", "host3"),
+						os.Getenv(constants.VcfTestVsanLicenseKey)),
+					testAccVcfClusterInDomainConfig(
+						"sfo-w01-cl02",
+						testGenerateHostsInClusterInDomainConfig(
+							os.Getenv(constants.VcfTestEsxiLicenseKey),
+							"sfo-w01-cl02",
+							"host4", "host5", "host6"),
+						os.Getenv(constants.VcfTestVsanLicenseKey))),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "vcenter.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "vcenter.0.fqdn"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "status"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "type"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "sso_id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "sso_name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.primary_datastore_name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.primary_datastore_type"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.is_default"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.is_stretched"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.host.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.host.1.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.host.2.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.primary_datastore_name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.primary_datastore_type"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.is_default"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.is_stretched"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.host.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.host.1.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.1.host.2.id"),
+					resource.TestCheckNoResourceAttr("vcf_domain.domain1", "cluster.1.host.3.id"),
+				),
+			},
+			{
+				// Remove additional cluster
+				Config: testAccVcfDomainConfig(
+					testGenerateCommissionHostConfigs(
+						7,
+						os.Getenv(constants.VcfTestHost2Fqdn),
+						os.Getenv(constants.VcfTestHost2Pass),
+						os.Getenv(constants.VcfTestHost3Fqdn),
+						os.Getenv(constants.VcfTestHost3Pass),
+						os.Getenv(constants.VcfTestHost4Fqdn),
+						os.Getenv(constants.VcfTestHost4Pass),
+						os.Getenv(constants.VcfTestHost5Fqdn),
+						os.Getenv(constants.VcfTestHost5Pass),
+						os.Getenv(constants.VcfTestHost6Fqdn),
+						os.Getenv(constants.VcfTestHost6Pass),
+						os.Getenv(constants.VcfTestHost7Fqdn),
+						os.Getenv(constants.VcfTestHost7Pass),
+						os.Getenv(constants.VcfTestHost8Fqdn),
+						os.Getenv(constants.VcfTestHost8Pass)),
+					os.Getenv(constants.VcfTestNsxLicenseKey),
+					testAccVcfClusterInDomainConfig(
+						"sfo-w01-cl01",
+						testGenerateHostsInClusterInDomainConfig(
+							os.Getenv(constants.VcfTestEsxiLicenseKey),
+							"sfo-w01-cl01",
+							"host1", "host2", "host3"),
+						os.Getenv(constants.VcfTestVsanLicenseKey)),
+					""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "vcenter.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "vcenter.0.fqdn"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "status"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "type"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "sso_id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "sso_name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.primary_datastore_name"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.primary_datastore_type"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.is_default"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.is_stretched"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.host.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.host.1.id"),
+					resource.TestCheckResourceAttrSet("vcf_domain.domain1", "cluster.0.host.2.id"),
+					resource.TestCheckNoResourceAttr("vcf_domain.domain1", "cluster.1.id"),
+				),
+			},
 		},
 	})
 }
@@ -228,7 +340,7 @@ func testAccVcfDomainConfig(commissionHostConfig, nsxLicenseKey,
 			name            = "test-vcenter"
 			datacenter_name = "test-datacenter"
 			root_password   = "S@mpleP@ss123!"
-			vm_size         = "medium"
+			vm_size         = "small"
 			storage_size    = "lstorage"
 			ip_address      = "10.0.0.43"
 			subnet_mask     = "255.255.255.0"


### PR DESCRIPTION
**Summary of Pull Request**

The domain update logic failed to do a refresh (read) just after the update operation has completed. This resulted in failing acceptance test, the fix to which was simple: execute a read at the end of domain update method. Some function parameter order was messed up.

Additionally, the Domain E2E test was expanded with:

Add a second cluster,
Add a forth host in the additional cluster,
Remove the forth host,
Remove the additional cluster

This way all update operations, currently supported for domain are tested.

Also optimise domain E2E test resource usage.


<!--
    Please provide a clear and concise description of the pull request.
-->

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [X] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

Testing done:
make lint
make build
make test

=== RUN   TestAccResourceVcfDomain
=== PAUSE TestAccResourceVcfDomain
=== CONT  TestAccResourceVcfDomain
--- PASS: TestAccResourceVcfDomain (16852.67s)
PASS

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
