### PR TITLE
feat: add support for ip pool range creation during cluster/domain creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v0.4.0](https://github.com/vmware/terraform-provider-vcf/releases/tag/v0.4.0)
 
-> Release Date: Sep 8th 2023
+> Release Date: Sep 11th 2023
 
 BREAKING CHANGES:
 
@@ -16,6 +16,7 @@ BREAKING CHANGES:
 FEATURES:
 * Extend support for host resource: import [\#36](https://github.com/vmware/terraform-provider-vcf/issues/36)
 * Add support for workload domain resource: import [\#35](https://github.com/vmware/terraform-provider-vcf/issues/35)
+* Add support for configuration of NSX host TEP pool (static / DHCP) in r/vcf_domain [\#54](https://github.com/vmware/terraform-provider-vcf/issues/54)
 
 **Note:** Management domain cannot be imported, but can be used as datasource
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -59,6 +59,7 @@ The following data is prerequisite for creation:
 - `evc_mode` (String) EVC mode for new cluster, if needed. One among: INTEL_MEROM, INTEL_PENRYN, INTEL_NEALEM, INTEL_WESTMERE, INTEL_SANDYBRIDGE, INTEL_IVYBRIDGE, INTEL_HASWELL, INTEL_BROADWELL, INTEL_SKYLAKE, INTEL_CASCADELAKE, AMD_REV_E, AMD_REV_F, AMD_GREYHOUND_NO3DNOW, AMD_GREYHOUND, AMD_BULLDOZER, AMD_PILEDRIVER, AMD_STREAMROLLER, AMD_ZEN
 - `geneve_vlan_id` (Number) VLAN ID use for NSX Geneve in the workload domain
 - `high_availability_enabled` (Boolean) vSphere High Availability settings for the cluster
+- `ip_address_pool` (Block List, Max: 1) Contains the parameters required to create or reuse an IP address pool. Omit for DHCP, provide name only to reuse existing IP Pool, if subnets are provided a new IP Pool will be created (see [below for nested schema](#nestedblock--ip_address_pool))
 - `nfs_datastores` (Block List) Cluster storage configuration for NFS (see [below for nested schema](#nestedblock--nfs_datastores))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `vmfs_datastore` (Block List, Max: 1) Cluster storage configuration for VMFS (see [below for nested schema](#nestedblock--vmfs_datastore))
@@ -146,6 +147,42 @@ Required:
 Optional:
 
 - `active_uplinks` (List of String) List of active uplinks associated with portgroup. This is only supported for VxRail.
+
+
+
+<a id="nestedblock--ip_address_pool"></a>
+### Nested Schema for `ip_address_pool`
+
+Required:
+
+- `name` (String) Providing only name of existing IP Address Pool reuses it, while providing a new name with subnets creates a new one
+
+Optional:
+
+- `description` (String) Description of the IP address pool
+- `ignore_unavailable_nsx_cluster` (Boolean) Ignore unavailable NSX cluster(s) during IP pool spec validation
+- `subnet` (Block List) List of IP address pool subnet specifications (see [below for nested schema](#nestedblock--ip_address_pool--subnet))
+
+<a id="nestedblock--ip_address_pool--subnet"></a>
+### Nested Schema for `ip_address_pool.subnet`
+
+Required:
+
+- `cidr` (String) The subnet representation, contains the network address and the prefix length
+- `gateway` (String) The default gateway address of the network
+
+Optional:
+
+- `ip_address_pool_range` (Block List) List of the IP allocation ranges. At least 1 IP address range has to be specified (see [below for nested schema](#nestedblock--ip_address_pool--subnet--ip_address_pool_range))
+
+<a id="nestedblock--ip_address_pool--subnet--ip_address_pool_range"></a>
+### Nested Schema for `ip_address_pool.subnet.ip_address_pool_range`
+
+Required:
+
+- `end` (String) The last IP Address of the IP Address Range
+- `start` (String) The first IP Address of the IP Address Range
+
 
 
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -88,6 +88,7 @@ Optional:
 - `evc_mode` (String) EVC mode for new cluster, if needed. One among: INTEL_MEROM, INTEL_PENRYN, INTEL_NEALEM, INTEL_WESTMERE, INTEL_SANDYBRIDGE, INTEL_IVYBRIDGE, INTEL_HASWELL, INTEL_BROADWELL, INTEL_SKYLAKE, INTEL_CASCADELAKE, AMD_REV_E, AMD_REV_F, AMD_GREYHOUND_NO3DNOW, AMD_GREYHOUND, AMD_BULLDOZER, AMD_PILEDRIVER, AMD_STREAMROLLER, AMD_ZEN
 - `geneve_vlan_id` (Number) VLAN ID use for NSX Geneve in the workload domain
 - `high_availability_enabled` (Boolean) vSphere High Availability settings for the cluster
+- `ip_address_pool` (Block List, Max: 1) Contains the parameters required to create or reuse an IP address pool. Omit for DHCP, provide name only to reuse existing IP Pool, if subnets are provided a new IP Pool will be created (see [below for nested schema](#nestedblock--cluster--ip_address_pool))
 - `nfs_datastores` (Block List) Cluster storage configuration for NFS (see [below for nested schema](#nestedblock--cluster--nfs_datastores))
 - `vmfs_datastore` (Block List, Max: 1) Cluster storage configuration for VMFS (see [below for nested schema](#nestedblock--cluster--vmfs_datastore))
 - `vsan_datastore` (Block List, Max: 1) Cluster storage configuration for vSAN (see [below for nested schema](#nestedblock--cluster--vsan_datastore))
@@ -174,6 +175,42 @@ Required:
 Optional:
 
 - `active_uplinks` (List of String) List of active uplinks associated with portgroup. This is only supported for VxRail.
+
+
+
+<a id="nestedblock--cluster--ip_address_pool"></a>
+### Nested Schema for `cluster.ip_address_pool`
+
+Required:
+
+- `name` (String) Providing only name of existing IP Address Pool reuses it, while providing a new name with subnets creates a new one
+
+Optional:
+
+- `description` (String) Description of the IP address pool
+- `ignore_unavailable_nsx_cluster` (Boolean) Ignore unavailable NSX cluster(s) during IP pool spec validation
+- `subnet` (Block List) List of IP address pool subnet specifications (see [below for nested schema](#nestedblock--cluster--ip_address_pool--subnet))
+
+<a id="nestedblock--cluster--ip_address_pool--subnet"></a>
+### Nested Schema for `cluster.ip_address_pool.subnet`
+
+Required:
+
+- `cidr` (String) The subnet representation, contains the network address and the prefix length
+- `gateway` (String) The default gateway address of the network
+
+Optional:
+
+- `ip_address_pool_range` (Block List) List of the IP allocation ranges. At least 1 IP address range has to be specified (see [below for nested schema](#nestedblock--cluster--ip_address_pool--subnet--ip_address_pool_range))
+
+<a id="nestedblock--cluster--ip_address_pool--subnet--ip_address_pool_range"></a>
+### Nested Schema for `cluster.ip_address_pool.subnet.ip_address_pool_range`
+
+Required:
+
+- `end` (String) The last IP Address of the IP Address Range
+- `start` (String) The first IP Address of the IP Address Range
+
 
 
 
@@ -273,6 +310,10 @@ Optional:
 
 - `form_factor` (String) Form factor for the NSX Manager appliance. One among: large, medium, small
 - `nsx_manager_audit_password` (String, Sensitive) NSX Manager audit user password
+
+Read-Only:
+
+- `id` (String) ID of the NSX Manager cluster
 
 <a id="nestedblock--nsx_configuration--nsx_manager_node"></a>
 ### Nested Schema for `nsx_configuration.nsx_manager_node`

--- a/internal/cluster/cluster_operations.go
+++ b/internal/cluster/cluster_operations.go
@@ -111,6 +111,7 @@ func TryConvertResourceDataToClusterSpec(data *schema.ResourceData) (*models.Clu
 	intermediaryMap["evc_mode"] = data.Get("evc_mode")
 	intermediaryMap["high_availability_enabled"] = data.Get("high_availability_enabled")
 	intermediaryMap["geneve_vlan_id"] = data.Get("geneve_vlan_id")
+	intermediaryMap["ip_address_pool"] = data.Get("ip_address_pool")
 	intermediaryMap["host"] = data.Get("host")
 	intermediaryMap["vds"] = data.Get("vds")
 	intermediaryMap["vsan_datastore"] = data.Get("vsan_datastore")
@@ -159,6 +160,17 @@ func TryConvertToClusterSpec(object map[string]interface{}) (*models.ClusterSpec
 
 	if geneveVlanId, ok := object["geneve_vlan_id"]; ok && !validationUtils.IsEmpty(geneveVlanId) {
 		result.NetworkSpec.NsxClusterSpec.NsxTClusterSpec.GeneveVlanID = int32(geneveVlanId.(int))
+	}
+
+	if ipAddressPoolRaw, ok := object["ip_address_pool"]; ok && !validationUtils.IsEmpty(ipAddressPoolRaw) {
+		ipAddressPoolList := ipAddressPoolRaw.([]interface{})
+		if !validationUtils.IsEmpty(ipAddressPoolList[0]) {
+			ipAddressPoolSpec, err := network.TryConvertToIPAddressPoolSpec(ipAddressPoolList[0].(map[string]interface{}))
+			if err != nil {
+				return nil, err
+			}
+			result.NetworkSpec.NsxClusterSpec.NsxTClusterSpec.IPAddressPoolSpec = ipAddressPoolSpec
+		}
 	}
 
 	if hostsRaw, ok := object["host"]; ok {

--- a/internal/network/ip_address_pool_subresource.go
+++ b/internal/network/ip_address_pool_subresource.go
@@ -90,6 +90,7 @@ func TryConvertToIPAddressPoolSpec(object map[string]interface{}) (*models.IPAdd
 	if len(name) == 0 {
 		return nil, fmt.Errorf("cannot convert to IPAddressPoolSpec, name is required")
 	}
+	result.Name = &name
 	if description, ok := object["description"]; ok && !validationutils.IsEmpty(description) {
 		result.Description = description.(string)
 	}

--- a/internal/network/ip_address_pool_subresource.go
+++ b/internal/network/ip_address_pool_subresource.go
@@ -1,0 +1,148 @@
+/*
+ *  Copyright 2023 VMware, Inc.
+ *    SPDX-License-Identifier: MPL-2.0
+ */
+
+package network
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	validationutils "github.com/vmware/terraform-provider-vcf/internal/validation"
+	"github.com/vmware/vcf-sdk-go/models"
+)
+
+// IpAddressPoolSchema this helper function extracts the IpAddressPoolSpec schema, which
+// contains the parameters required to create or reuse an IP address pool.
+func IpAddressPoolSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type: schema.TypeString,
+				Description: "Providing only name of existing IP Address Pool reuses it, " +
+					"while providing a new name with subnets creates a new one",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Description of the IP address pool",
+				Optional:    true,
+			},
+			"ignore_unavailable_nsx_cluster": {
+				Type:        schema.TypeBool,
+				Description: "Ignore unavailable NSX cluster(s) during IP pool spec validation",
+				Optional:    true,
+			},
+			"subnet": {
+				Type:        schema.TypeList,
+				Description: "List of IP address pool subnet specifications",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr": {
+							Type:         schema.TypeString,
+							Description:  "The subnet representation, contains the network address and the prefix length",
+							Required:     true,
+							ValidateFunc: validation.IsCIDR,
+						},
+						"gateway": {
+							Type:         schema.TypeString,
+							Description:  "The default gateway address of the network",
+							Required:     true,
+							ValidateFunc: validationutils.ValidateIPv4AddressSchema,
+						},
+						"ip_address_pool_range": {
+							Type:        schema.TypeList,
+							Description: "List of the IP allocation ranges. At least 1 IP address range has to be specified",
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"start": {
+										Type:         schema.TypeString,
+										Description:  "The first IP Address of the IP Address Range",
+										Required:     true,
+										ValidateFunc: validationutils.ValidateIPv4AddressSchema,
+									},
+									"end": {
+										Type:         schema.TypeString,
+										Description:  "The last IP Address of the IP Address Range",
+										Required:     true,
+										ValidateFunc: validationutils.ValidateIPv4AddressSchema,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TryConvertToIPAddressPoolSpec(object map[string]interface{}) (*models.IPAddressPoolSpec, error) {
+	result := &models.IPAddressPoolSpec{}
+	if object == nil {
+		return nil, fmt.Errorf("cannot convert to IPAddressPoolSpec, object is nil")
+	}
+	name := object["name"].(string)
+	if len(name) == 0 {
+		return nil, fmt.Errorf("cannot convert to IPAddressPoolSpec, name is required")
+	}
+	if description, ok := object["description"]; ok && !validationutils.IsEmpty(description) {
+		result.Description = description.(string)
+	}
+	if ignoreUnavailableNsxCluster, ok := object["ignore_unavailable_nsx_cluster"]; ok && !validationutils.IsEmpty(ignoreUnavailableNsxCluster) {
+		result.IgnoreUnavailableNSXTCluster = ignoreUnavailableNsxCluster.(bool)
+	}
+	if subnetsRaw, ok := object["subnet"]; ok {
+		subnetsList := subnetsRaw.([]interface{})
+		if len(subnetsList) > 0 {
+			result.Subnets = []*models.IPAddressPoolSubnetSpec{}
+			for _, subnetsListEntry := range subnetsList {
+				iPAddressPoolSubnetSpec, err := tryConvertToIPAddressPoolSubnetSpec(subnetsListEntry.(map[string]interface{}))
+				if err != nil {
+					return nil, err
+				}
+				result.Subnets = append(result.Subnets, iPAddressPoolSubnetSpec)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func tryConvertToIPAddressPoolSubnetSpec(object map[string]interface{}) (*models.IPAddressPoolSubnetSpec, error) {
+	result := &models.IPAddressPoolSubnetSpec{}
+	if object == nil {
+		return nil, fmt.Errorf("cannot convert to IPAddressPoolSubnetSpec, object is nil")
+	}
+	cidr := object["cidr"].(string)
+	if len(cidr) == 0 {
+		return nil, fmt.Errorf("cannot convert to IPAddressPoolSubnetSpec, cidr is required")
+	}
+	gateway := object["gateway"].(string)
+	if len(gateway) == 0 {
+		return nil, fmt.Errorf("cannot convert to IPAddressPoolSubnetSpec, gateway is required")
+	}
+	result.Cidr = &cidr
+	result.Gateway = &gateway
+	if ipAddressPoolRangeRaw, ok := object["ip_address_pool_range"]; ok {
+		ipAddressPoolRangeList := ipAddressPoolRangeRaw.([]interface{})
+		if len(ipAddressPoolRangeList) > 0 {
+			result.IPAddressPoolRanges = []*models.IPAddressPoolRangeSpec{}
+			for _, ipAddressPoolRangeEntry := range ipAddressPoolRangeList {
+				ipAddressPoolSubnetSpec := models.IPAddressPoolRangeSpec{}
+				ipAddressPoolRangeMap := ipAddressPoolRangeEntry.(map[string]interface{})
+				start := ipAddressPoolRangeMap["start"].(string)
+				end := ipAddressPoolRangeMap["end"].(string)
+				ipAddressPoolSubnetSpec.Start = &start
+				ipAddressPoolSubnetSpec.End = &end
+				result.IPAddressPoolRanges = append(result.IPAddressPoolRanges, &ipAddressPoolSubnetSpec)
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/internal/network/nsx_subresource.go
+++ b/internal/network/nsx_subresource.go
@@ -49,9 +49,9 @@ func NsxSchema() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"form_factor": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Form factor for the NSX Manager appliance. One among: large, medium, small",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Form factor for the NSX Manager appliance. One among: large, medium, small",
 				ValidateFunc: validation.StringInSlice([]string{
 					"large", "medium", "small",
 				}, true),

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -157,6 +157,14 @@ func clusterSubresourceSchema() *schema.Resource {
 				Description:  "VLAN ID use for NSX Geneve in the workload domain",
 				ValidateFunc: validation.IntBetween(0, 4095),
 			},
+			"ip_address_pool": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Description: "Contains the parameters required to create or reuse an IP address pool. Omit for DHCP, " +
+					"provide name only to reuse existing IP Pool, if subnets are provided a new IP Pool will be created",
+				Elem: network.IpAddressPoolSchema(),
+			},
 			"vds": {
 				Type:        schema.TypeList,
 				Required:    true,

--- a/internal/provider/resource_cluster_test.go
+++ b/internal/provider/resource_cluster_test.go
@@ -19,7 +19,41 @@ import (
 	"testing"
 )
 
-func TestAccResourceVcfCluster(t *testing.T) {
+func TestAccResourceVcfClusterCreate(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testCheckVcfClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVcfClusterResourceConfig(
+					os.Getenv(constants.VcfTestDomainDataSourceId),
+					os.Getenv(constants.VcfTestHost5Fqdn),
+					os.Getenv(constants.VcfTestHost5Pass),
+					os.Getenv(constants.VcfTestHost6Fqdn),
+					os.Getenv(constants.VcfTestHost6Pass),
+					os.Getenv(constants.VcfTestHost7Fqdn),
+					os.Getenv(constants.VcfTestHost7Pass),
+					os.Getenv(constants.VcfTestEsxiLicenseKey),
+					os.Getenv(constants.VcfTestVsanLicenseKey),
+					"",
+					""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "name"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "primary_datastore_name"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "primary_datastore_type"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "is_default"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "is_stretched"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "host.0.id"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "host.1.id"),
+					resource.TestCheckResourceAttrSet("vcf_cluster.cluster1", "host.2.id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVcfClusterFull(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -253,6 +287,21 @@ func testAccVcfClusterResourceConfig(domainId, host1Fqdn, host1Pass, host2Fqdn, 
 			portgroup {
 				name = "sfo-m01-cl01-vds01-pg-vmotion"
 				transport_type = "VMOTION"
+			}
+		}
+		ip_address_pool {
+			name = "static-ip-pool-01"
+			subnet {
+				cidr = "10.0.11.0/24"
+				gateway = "10.0.11.250"
+				ip_address_pool_range {
+					start = "10.0.11.50"
+					end = "10.0.11.70"
+				}
+				ip_address_pool_range {
+					start = "10.0.11.80"
+					end = "10.0.11.150"
+				}
 			}
 		}
 		vsan_datastore {

--- a/internal/validation/validation_utils.go
+++ b/internal/validation/validation_utils.go
@@ -193,6 +193,12 @@ func IsEmpty(object interface{}) bool {
 			return false
 		}
 	}
+	objectAnyMap, ok := object.(map[string]interface{})
+	if ok {
+		if len(objectAnyMap) > 0 {
+			return false
+		}
+	}
 	_, ok = object.(int)
 
 	return !ok

--- a/internal/validation/validation_utils_test.go
+++ b/internal/validation/validation_utils_test.go
@@ -101,3 +101,29 @@ func TestValidateIpv4Address(t *testing.T) {
 		}
 	})
 }
+
+func TestIsEmpty(t *testing.T) {
+	t.Run("is object empty", func(t *testing.T) {
+		var nonEmptyMap = make(map[string]interface{})
+		nonEmptyMap["name"] = "SlavaZSU"
+		var isEmptyTests = []struct {
+			object         interface{}
+			expectedResult bool
+		}{
+			{"some string", false},
+			{nil, true},
+			{true, false},
+			{new([]interface{}), true},
+			{make(map[string]interface{}), true},
+			{append(make([]interface{}, 0), "first", "second"), false},
+			{nonEmptyMap, false},
+		}
+
+		for _, emptyTest := range isEmptyTests {
+			result := IsEmpty(emptyTest.object)
+			if emptyTest.expectedResult != result {
+				t.Errorf("%s test failed", emptyTest.object)
+			}
+		}
+	})
+}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Introduced  E2E test TestAccResourceVcfClusterCreate, which has a smaller footprint than the TestAccResourceVcfCluster, now renamed to TestAccResourceVcfClusterFull. Added an ip_address_pool attribute to the cluster tests. Navigated to NSX UI and observed "static-ip-pool-01" present under Networking -> IP Address Pools.

Fix indentation in the nsx_subresource.go's "form_factor" attribute definition, that was cryptically reported by the linter

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [X] This is a code style/formatting update.
- [X] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #54 

**Test and Documentation Coverage**

make build
make lint
make test

=== RUN   TestAccResourceVcfClusterCreate
=== PAUSE TestAccResourceVcfClusterCreate
=== CONT  TestAccResourceVcfClusterCreate
--- PASS: TestAccResourceVcfClusterCreate (3338.29s)
PASS

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
