### PR TITLE
Redefine the upper boundary for Edge Cluster and Edge Node ASN setting

### DIFF
--- a/internal/nsx_edge_cluster/edge_node_subresource.go
+++ b/internal/nsx_edge_cluster/edge_node_subresource.go
@@ -151,7 +151,7 @@ func BgpPeerSchema() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				Description:  "ASN",
-				ValidateFunc: validation.IntBetween(1, int(math.Pow(2, 32))),
+				ValidateFunc: validation.IntBetween(1, int(math.Pow(2, 31)-1)),
 			},
 		},
 	}

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -116,7 +116,7 @@ func ResourceEdgeCluster() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "ASN for the cluster",
-				ValidateFunc: validation.IntBetween(1, int(math.Pow(2, 32))),
+				ValidateFunc: validation.IntBetween(1, int(math.Pow(2, 31)-1)),
 			},
 			"skip_tep_routability_check": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
**Summary of Pull Request**

The upper limit that the SDDC manager enforces on ASN values is 2^32 (4294967295).
In our code this is evaluated by raising 2 to the power of 32 and trying to cast it into the default integer.
On systems where Golang's integer defaults to 32-bit signed this cannot be enforced since it will overflow and actually produce a negative value.

Even if we change the validation util to work with int64 the input values would theoretically overflow since Terraform's integer inputs use the default int type.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #120

**Test and Documentation Coverage**

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
