### PR TITLE
Respect IP Pool configuration for NSX subresource

### DIFF
--- a/internal/provider/resource_vcf_instance_test.go
+++ b/internal/provider/resource_vcf_instance_test.go
@@ -145,6 +145,17 @@ func testAccCheckVcfSddcConfigBasic() string {
 		vip_fqdn = "vip-nsx-mgmt"
 		license = %q
 		transport_vlan_id = 0
+		ip_address_pool {
+		  name = "static-pool-1"
+		  subnet {
+		    cidr = "10.0.8.4/24"
+		    gateway = "10.0.8.253"
+		    ip_address_pool_range {
+		      start = "10.0.8.4"
+		      end = "10.0.8.16"
+		    }
+		  }
+		}
 	  }
 	  vsan {
 		license = %q

--- a/internal/sddc/sddc_nsx_subresource.go
+++ b/internal/sddc/sddc_nsx_subresource.go
@@ -158,6 +158,14 @@ func GetNsxSpecFromSchema(rawData []interface{}) *models.SDDCNSXTSpec {
 	if overLayTransportZoneData := getTransportZoneFromSchema(data["overlay_transport_zone"].([]interface{})); overLayTransportZoneData != nil {
 		nsxtSpecBinding.OverLayTransportZone = overLayTransportZoneData
 	}
+
+	if ipAddressPoolRaw, ok := data["ip_address_pool"]; ok && !validation_utils.IsEmpty(ipAddressPoolRaw) {
+		ipAddressPoolList := ipAddressPoolRaw.([]interface{})
+		// Only one IP Address pool spec is allowed in the resource
+		if ipAddressPoolSpec, err := network.GetIpAddressPoolSpecFromSchema(ipAddressPoolList[0].(map[string]interface{})); err == nil {
+			nsxtSpecBinding.IPAddressPoolSpec = ipAddressPoolSpec
+		}
+	}
 	return nsxtSpecBinding
 }
 


### PR DESCRIPTION
**Summary of Pull Request**

The ip pool configuration is being omitted from the specification when configuring NSX.
I am populating IPAddressPoolSpec if "ip_address_pool" is set before issuing API call.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

https://github.com/vmware/terraform-provider-vcf/issues/113

**Test and Documentation Coverage**

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.