### PR TITLE
fix: rename incorrect property in edge node example

### DIFF
--- a/examples/resources/edge_cluster/variables.tf
+++ b/examples/resources/edge_cluster/variables.tf
@@ -1,4 +1,4 @@
-ariable "sddc_manager_username" {
+variable "sddc_manager_username" {
   description = "Username used to authenticate against an SDDC Manager instance."
   default     = ""
 }

--- a/examples/resources/edge_cluster/vcf_edge_cluster.tf
+++ b/examples/resources/edge_cluster/vcf_edge_cluster.tf
@@ -28,7 +28,7 @@ resource "vcf_edge_cluster" "cluster_1" {
 
   edge_node {
     name               = var.edge_node_1_name
-    cluster_id         = var.compute_cluster_id
+    compute_cluster_id = var.compute_cluster_id
     root_password      = var.edge_node_1_root_pass
     admin_password     = var.edge_node_1_admin_pass
     audit_password     = var.edge_node_1_audit_pass
@@ -63,7 +63,7 @@ resource "vcf_edge_cluster" "cluster_1" {
 
   edge_node {
     name               = var.edge_node_2_name
-    cluster_id         = var.compute_cluster_id
+    compute_cluster_id = var.compute_cluster_id
     root_password      = var.edge_node_2_root_pass
     admin_password     = var.edge_node_2_admin_pass
     audit_password     = var.edge_node_2_audit_pass


### PR DESCRIPTION
**Summary of Pull Request**

Fixes incorrect keys and variables in edge cluster example.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #131

**Test and Documentation Coverage**

Ran "terraform plan" on the example configuration to make sure there are no more typo's and incorrect keys

For bug fixes or features:

- [x] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
