### PR TITLE
Fix cluster creation with a vLCM image

### DIFF
--- a/internal/cluster/cluster_operations.go
+++ b/internal/cluster/cluster_operations.go
@@ -105,7 +105,7 @@ func ValidateClusterUpdateOperation(ctx context.Context, clusterId string,
 func TryConvertResourceDataToClusterSpec(data *schema.ResourceData) (*models.ClusterSpec, error) {
 	intermediaryMap := map[string]interface{}{}
 	intermediaryMap["name"] = data.Get("name")
-	intermediaryMap["clusterImageId"] = data.Get("clusterImageId")
+	intermediaryMap["cluster_image_id"] = data.Get("cluster_image_id")
 	intermediaryMap["evc_mode"] = data.Get("evc_mode")
 	intermediaryMap["high_availability_enabled"] = data.Get("high_availability_enabled")
 	intermediaryMap["geneve_vlan_id"] = data.Get("geneve_vlan_id")


### PR DESCRIPTION
**Summary of Pull Request**

The option to create a cluster with a predefined vLCM image is implemented but doesn't work due to a simple string mismatch

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
