### PR TITLE
Configure optional properties for edge clusters and nodes

### DIFF
--- a/docs/resources/edge_cluster.md
+++ b/docs/resources/edge_cluster.md
@@ -36,21 +36,21 @@ Review the documentation for VMware Cloud Foundation for more information about 
 - `audit_password` (String) Audit user password for the NSX manager
 - `edge_node` (Block List, Min: 1) The nodes in the edge cluster (see [below for nested schema](#nestedblock--edge_node))
 - `form_factor` (String) One among: XLARGE, LARGE, MEDIUM, SMALL
-- `high_availability` (String) One among: ACTIVE_ACTIVE, ACTIVE_STANDBY
 - `mtu` (Number) Maximum transmission unit size for the cluster
 - `name` (String) The name of the edge cluster
 - `profile_type` (String) One among: DEFAULT, CUSTOM. If set to CUSTOM a 'profile' must be provided
 - `root_password` (String) Root user password for the NSX manager
-- `routing_type` (String) One among: EBGP, STATIC
-- `tier0_name` (String) Name for the Tier-0 gateway
-- `tier1_name` (String) Name for the Tier-1 gateway
 
 ### Optional
 
 - `asn` (Number) ASN for the cluster
+- `high_availability` (String) One among: ACTIVE_ACTIVE, ACTIVE_STANDBY
 - `internal_transit_subnets` (List of String) Subnet addresses in CIDR notation that are used to assign addresses to logical links connecting service routers and distributed routers
 - `profile` (Block List, Max: 1) The specification for the edge cluster profile (see [below for nested schema](#nestedblock--profile))
+- `routing_type` (String) One among: EBGP, STATIC
 - `skip_tep_routability_check` (Boolean) Set to true to bypass normal ICMP-based check of Edge TEP / host TEP routability (default is false, meaning do check)
+- `tier0_name` (String) Name for the Tier-0 gateway
+- `tier1_name` (String) Name for the Tier-1 gateway
 - `tier1_unhosted` (Boolean) Select whether Tier-1 being created per this spec is hosted on the new Edge cluster or not (default value is false, meaning hosted)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `transit_subnets` (List of String) Transit subnet addresses in CIDR notation that are used to assign addresses to logical links connecting Tier-0 and Tier-1s
@@ -80,8 +80,18 @@ Required:
 Optional:
 
 - `first_nsx_vds_uplink` (String) The name of the first NSX-enabled VDS uplink
+- `management_network` (Block List, Max: 1) The management network which will be created for this node (see [below for nested schema](#nestedblock--edge_node--management_network))
 - `second_nsx_vds_uplink` (String) The name of the second NSX-enabled VDS uplink
 - `uplink` (Block List) Specifications of Tier-0 uplinks for the edge node (see [below for nested schema](#nestedblock--edge_node--uplink))
+
+<a id="nestedblock--edge_node--management_network"></a>
+### Nested Schema for `edge_node.management_network`
+
+Required:
+
+- `portgroup_name` (String) The name of the portgroup
+- `vlan_id` (Number) The VLAN ID for the portgroup
+
 
 <a id="nestedblock--edge_node--uplink"></a>
 ### Nested Schema for `edge_node.uplink`
@@ -102,7 +112,7 @@ Required:
 
 - `asn` (Number) ASN
 - `ip` (String) IP address
-- `password` (String) Password - can be empty.
+- `password` (String) Password
 
 
 

--- a/docs/resources/network_pool.md
+++ b/docs/resources/network_pool.md
@@ -44,6 +44,10 @@ The following data is prerequisite for creating a new Network Pool
 <a id="nestedblock--network"></a>
 ### Nested Schema for `network`
 
+Required:
+
+- `vlan_id` (Number) VLAN ID associated with the network
+
 Optional:
 
 - `gateway` (String) Gateway for the network
@@ -52,7 +56,6 @@ Optional:
 - `mtu` (Number) Gateway for the network
 - `subnet` (String) Subnet associated with the network
 - `type` (String) Network Type of the network
-- `vlan_id` (Number) VLAN ID associated with the network
 
 <a id="nestedblock--network--ip_pools"></a>
 ### Nested Schema for `network.ip_pools`
@@ -70,5 +73,3 @@ Optional:
 Optional:
 
 - `create` (String)
-
-

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.9.0
-	github.com/vmware/vcf-sdk-go v0.3.1
+	github.com/vmware/vcf-sdk-go v0.3.2
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 )
 

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/vmware/vcf-sdk-go v0.3.1 h1:pPsO/ILzQFCWiAf47Mx7q+GBtDgwm7hn4CtXoS3J4w0=
 github.com/vmware/vcf-sdk-go v0.3.1/go.mod h1:EXM19ZwD2qmvMVSvgUzcnT7dSTCq3lzv84ErrFPZm1Q=
+github.com/vmware/vcf-sdk-go v0.3.2 h1:WhmIs7Xx4NePg2/VgaFBBfjZ7NG0W9W8+JmvWey59HU=
+github.com/vmware/vcf-sdk-go v0.3.2/go.mod h1:EXM19ZwD2qmvMVSvgUzcnT7dSTCq3lzv84ErrFPZm1Q=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/nsx_edge_cluster/edge_cluster_operations.go
+++ b/internal/nsx_edge_cluster/edge_cluster_operations.go
@@ -30,6 +30,7 @@ func GetNsxEdgeClusterCreationSpec(data *schema.ResourceData) *models.EdgeCluste
 	mtu := int32(data.Get("mtu").(int))
 	asn := int64(data.Get("asn").(int))
 	tier1Unhosted := data.Get("tier1_unhosted").(bool)
+	skipTepRoutabilityCheck := data.Get("skip_tep_routability_check").(bool)
 
 	transitSubnets := resource_utils.ToStringSlice(data.Get("transit_subnets").([]interface{}))
 	internalTransitSubnets := resource_utils.ToStringSlice(data.Get("internal_transit_subnets").([]interface{}))
@@ -62,6 +63,7 @@ func GetNsxEdgeClusterCreationSpec(data *schema.ResourceData) *models.EdgeCluste
 		Tier1Name:                     tier1Name,
 		Tier1Unhosted:                 tier1Unhosted,
 		TransitSubnets:                transitSubnets,
+		SkipTepRoutabilityCheck:       skipTepRoutabilityCheck,
 	}
 
 	return spec
@@ -162,6 +164,16 @@ func getNodeSpec(node map[string]interface{}) *models.NsxTEdgeNodeSpec {
 		SecondNsxVdsUplink: secondVdsUplink,
 		InterRackCluster:   &interRackCluster,
 		UplinkNetwork:      getUplinkNetworkSpecs(node),
+	}
+
+	mgmtNetworkRaw := node["management_network"].([]interface{})
+	if len(mgmtNetworkRaw) > 0 {
+		mgmtNetworkData := mgmtNetworkRaw[0].(map[string]interface{})
+		name := mgmtNetworkData["portgroup_name"].(string)
+		vlan := int32(mgmtNetworkData["vlan_id"].(int))
+
+		nodeSpec.VMManagementPortgroupName = &name
+		nodeSpec.VMManagementPortgroupVlan = &vlan
 	}
 
 	return nodeSpec

--- a/internal/nsx_edge_cluster/edge_node_subresource.go
+++ b/internal/nsx_edge_cluster/edge_node_subresource.go
@@ -84,6 +84,28 @@ func EdgeNodeSchema() *schema.Resource {
 				Description:  "The gateway address for the management network",
 				ValidateFunc: validationUtils.ValidateIPv4AddressSchema,
 			},
+			"management_network": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The management network which will be created for this node",
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"portgroup_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The name of the portgroup",
+							ValidateFunc: validation.NoZeroValues,
+						},
+						"vlan_id": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							Description:  "The VLAN ID for the portgroup",
+							ValidateFunc: validation.IntBetween(0, 4095),
+						},
+					},
+				},
+			},
 			"first_nsx_vds_uplink": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -65,13 +65,13 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"tier0_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  "Name for the Tier-0 gateway",
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"tier1_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  "Name for the Tier-1 gateway",
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -90,7 +90,8 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"routing_type": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				RequiredWith: []string{"tier0_name"},
 				Description:  "One among: EBGP, STATIC",
 				ValidateFunc: validation.StringInSlice([]string{"EBGP", "STATIC"}, false),
 			},
@@ -102,7 +103,8 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"high_availability": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				RequiredWith: []string{"tier0_name"},
 				Description:  "One among: ACTIVE_ACTIVE, ACTIVE_STANDBY",
 				ValidateFunc: validation.StringInSlice([]string{"ACTIVE_ACTIVE", "ACTIVE_STANDBY"}, false),
 			},

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -109,7 +109,7 @@ func getEdgeClusterConfigExpansion() string {
 		"192.168.19.3/24")
 	edgeNode3 := getEdgeNodeConfig(
 		edgeNode3Name,
-		"10.0.0.55/24",
+		"10.0.0.54/24",
 		"192.168.52.16/24",
 		"192.168.52.17/24",
 		"192.168.18.6/24",

--- a/internal/provider/resource_network_pool.go
+++ b/internal/provider/resource_network_pool.go
@@ -69,7 +69,7 @@ func ResourceNetworkPool() *schema.Resource {
 						"vlan_id": {
 							Type:        schema.TypeInt,
 							Description: "VLAN ID associated with the network",
-							Optional:    true,
+							Required:    true,
 						},
 						"ip_pools": {
 							Type:        schema.TypeList,


### PR DESCRIPTION
**Summary of Pull Request**

This PR contains 4 changes

1. Tier 0 and Tier 1 routers are now optional for Edge Clusters. 
Several other properties that are only required when a Tier 0 router is configured are also being marked as optional.

2. I'm adding new properties to Edge nodes for configuring a new management network for new nodes.
These are optional. I am not including them in the acceptance tests since they complicate the testing setup.

3. I'm fixing the VLAN ID for network pools. 0 is now a valid and accepted value.

4. I'm fixing "skip_tep_routability_check" which is currently being ignored

**Type of Pull Request**

- [X] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #177
Closes #175
Closes #147

**Test and Documentation Coverage**

Ran `TestAccResourceEdgeCluster` and `TestAccResourceVcfNetworkPool`

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
