### PR TITLE
feat: enable vum-based bringup via `r/vcf_instance`

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -103,6 +103,7 @@ Required:
 Optional:
 
 - `cluster_evc_mode` (String) vCenter cluster EVC mode
+- `cluster_image_enabled` (Boolean) Whether to enable vSphere Lifecycle Manager images for this cluster
 - `host_failures_to_tolerate` (Number) Host failures to tolerate. In between 0 and 3
 - `resource_pool` (Block List) (see [below for nested schema](#nestedblock--cluster--resource_pool))
 - `vm_folder` (Map of String) Virtual Machine folders map. One among: MANAGEMENT, NETWORKING

--- a/internal/provider/resource_vcf_instance_test.go
+++ b/internal/provider/resource_vcf_instance_test.go
@@ -90,7 +90,6 @@ func testAccCheckVcfSddcConfigBasic() string {
 	  dns {
 		domain = "vrack.vsphere.local"
 		name_server = "10.0.0.250"
-		secondary_name_server = "10.0.0.250"
 	  }
 	  network {
 		subnet = "10.0.0.0/22"

--- a/internal/sddc/sddc_cluster_subresource.go
+++ b/internal/sddc/sddc_cluster_subresource.go
@@ -37,6 +37,12 @@ func GetSddcClusterSchema() *schema.Schema {
 					Optional:     true,
 					ValidateFunc: validation.IntBetween(0, 3),
 				},
+				"cluster_image_enabled": {
+					Type:        schema.TypeBool,
+					Description: "Whether to enable vSphere Lifecycle Manager images for this cluster",
+					Optional:    true,
+					Default:     true,
+				},
 				"resource_pool": getResourcePoolSchema(),
 				"vm_folder": {
 					Type:        schema.TypeMap,
@@ -159,6 +165,7 @@ func GetSddcClusterSpecFromSchema(rawData []interface{}) *models.SDDCClusterSpec
 	clusterName := utils.ToStringPointer(data["cluster_name"])
 	clusterEvcMode := data["cluster_evc_mode"].(string)
 	hostFailuresToTolerate := utils.ToInt32Pointer(data["host_failures_to_tolerate"])
+	clusterImageEnabled := data["cluster_image_enabled"].(bool)
 	var vmFolder map[string]string
 	if !validation2.IsEmpty(data["vm_folder"]) {
 		vmFolder = data["vm_folder"].(map[string]string)
@@ -169,6 +176,7 @@ func GetSddcClusterSpecFromSchema(rawData []interface{}) *models.SDDCClusterSpec
 		ClusterName:            clusterName,
 		HostFailuresToTolerate: hostFailuresToTolerate,
 		VMFolders:              vmFolder,
+		ClusterImageEnabled:    clusterImageEnabled,
 	}
 
 	if resourcePoolSpecs := getResourcePoolSpecsFromSchema(


### PR DESCRIPTION
**Summary of Pull Request**

Enable VUM-based bringup via `resource_vcf_instance`.

I am adding a new property `cluster_image_enabled` which when set to `false` disables vLCM when deploying a management domain.

The default value inferred by the API for this property is `true`.

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #151

**Test and Documentation Coverage**

Ran `TestAccResourceVcfSddcBasic`

I did a minor fix to the test that I forgot to submit along with the SDK upgrade.
The secondary DNS can no longer match the primary DNS and the API fails in VCF 5.X

To resolve this I've simply removed the secondary DNS from the test since it's optional

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [X] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

`resource_vcf_instance` will stop working for 4.x releases since the new property will not be available.
