### PR TITLE
feat: accept entity names as inputs for several resources

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -49,7 +49,6 @@ The following data is prerequisite for creation:
 
 ### Required
 
-- `domain_id` (String) The ID of a workload domain that the cluster belongs to
 - `host` (Block List, Min: 2) List of ESXi host information from the free pool to consume in a workload domain/ The minimum of 3 hosts is required for vSAN based clusters. For external storage, 2 host clusters are also supported. (see [below for nested schema](#nestedblock--host))
 - `name` (String) Name of the cluster to add to the workload domain
 - `vds` (Block List, Min: 1) vSphere Distributed Switches to add to the cluster (see [below for nested schema](#nestedblock--vds))
@@ -57,6 +56,8 @@ The following data is prerequisite for creation:
 ### Optional
 
 - `cluster_image_id` (String) ID of the cluster image to be used with the cluster
+- `domain_id` (String) The ID of a workload domain that the cluster belongs to. You cannot specify a value for `domain_name` if you set this attribute.
+- `domain_name` (String) The name of a workload domain that the cluster belongs to. You cannot specify a value for `domain_id` if you set this attribute.
 - `evc_mode` (String) EVC mode for new cluster, if needed. One among: INTEL_MEROM, INTEL_PENRYN, INTEL_NEALEM, INTEL_WESTMERE, INTEL_SANDYBRIDGE, INTEL_IVYBRIDGE, INTEL_HASWELL, INTEL_BROADWELL, INTEL_SKYLAKE, INTEL_CASCADELAKE, AMD_REV_E, AMD_REV_F, AMD_GREYHOUND_NO3DNOW, AMD_GREYHOUND, AMD_BULLDOZER, AMD_PILEDRIVER, AMD_STREAMROLLER, AMD_ZEN
 - `geneve_vlan_id` (Number) VLAN ID use for NSX Geneve in the workload domain
 - `high_availability_enabled` (Boolean) vSphere High Availability settings for the cluster

--- a/docs/resources/edge_cluster.md
+++ b/docs/resources/edge_cluster.md
@@ -66,7 +66,6 @@ Required:
 
 - `admin_password` (String) The administrator password for the edge node
 - `audit_password` (String) The audit password for the edge node
-- `compute_cluster_id` (String) The id of the compute cluster
 - `inter_rack_cluster` (Boolean) Whether or not this is an inter-rack cluster. True for L2 non-uniform and L3, false for L2 uniform
 - `management_gateway` (String) The gateway address for the management network
 - `management_ip` (String) The IP address (CIDR) for the management network
@@ -79,6 +78,8 @@ Required:
 
 Optional:
 
+- `compute_cluster_id` (String) The id of the compute cluster. You cannot specify a value for `compute_cluster_name` if you set this attribute.
+- `compute_cluster_name` (String) The name of the compute cluster. You cannot specify a value for `compute_cluster_id` if you set this attribute.
 - `first_nsx_vds_uplink` (String) The name of the first NSX-enabled VDS uplink
 - `management_network` (Block List, Max: 1) The management network which will be created for this node (see [below for nested schema](#nestedblock--edge_node--management_network))
 - `second_nsx_vds_uplink` (String) The name of the second NSX-enabled VDS uplink

--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -43,13 +43,14 @@ BIOS, HBA, SSD, HDD, etc. of the host must match the VMware Hardware Compatibili
 ### Required
 
 - `fqdn` (String) FQDN of the host
-- `network_pool_id` (String) ID of the network pool to associate the host with
 - `password` (String, Sensitive) Password of the host
 - `storage_type` (String) Storage Type. One among: VSAN, VSAN_REMOTE, NFS, VMFS_FC, VVOL
-- `username` (String) Username of the host
+- `username` (String) Username to authenticate to the ESXi host
 
 ### Optional
 
+- `network_pool_id` (String) ID of the network pool to associate the ESXi host with. You cannot specify a value for `network_pool_name` if you set this attribute.
+- `network_pool_name` (String) Name of the network pool to associate the ESXi host with. You cannot specify a value for `network_pool_id` if you set this attribute.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -123,7 +123,7 @@ const (
 	// already created during bringup.
 	VcfTestClusterDataSourceId = "VCF_CLUSTER_DATA_SOURCE_ID"
 
-	// VcfTestDomainName id of the workload domain used in the acceptance tests
+	// VcfTestDomainName display name of the workload domain used in the acceptance tests.
 	VcfTestDomainName = "VCF_DOMAIN_NAME"
 
 	// VcfTestNetworkPoolName used in vcf_network_pool Acceptance tests.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -123,6 +123,9 @@ const (
 	// already created during bringup.
 	VcfTestClusterDataSourceId = "VCF_CLUSTER_DATA_SOURCE_ID"
 
+	// VcfTestDomainName id of the workload domain used in the acceptance tests
+	VcfTestDomainName = "VCF_DOMAIN_NAME"
+
 	// VcfTestNetworkPoolName used in vcf_network_pool Acceptance tests.
 	VcfTestNetworkPoolName = "terraform-test-pool"
 
@@ -164,6 +167,9 @@ const (
 
 	// VcfTestComputeClusterId the identifier of the compute cluster that will contain the edge nodes.
 	VcfTestComputeClusterId = "VCF_TEST_COMPUTE_CLUSTER_ID"
+
+	// VcfTestComputeClusterName the display name of the compute cluster that will contain the edge nodes.
+	VcfTestComputeClusterName = "VCF_TEST_COMPUTE_CLUSTER_NAME"
 )
 
 func GetIso3166CountryCodes() []string {

--- a/internal/nsx_edge_cluster/edge_cluster_operations.go
+++ b/internal/nsx_edge_cluster/edge_cluster_operations.go
@@ -43,8 +43,8 @@ func GetNsxEdgeClusterCreationSpec(data *schema.ResourceData, client *client.Vcf
 	nodes := data.Get("edge_node").([]interface{})
 	nodeSpecs := make([]*models.NsxTEdgeNodeSpec, 0, len(nodes))
 
-	for _, n := range nodes {
-		node := n.(map[string]interface{})
+	for _, node := range nodes {
+		node := node.(map[string]interface{})
 		nodeSpec, err := getNodeSpec(node, client)
 		if err != nil {
 			return nil, err
@@ -98,7 +98,8 @@ func GetNsxEdgeClusterShrinkageSpec(currentNodes []*models.EdgeNodeReference, ne
 	}
 }
 
-func GetNsxEdgeClusterExpansionSpec(currentNodes []*models.EdgeNodeReference, newNodesRaw []interface{}, client *client.VcfClient) (*models.EdgeClusterExpansionSpec, error) {
+func GetNsxEdgeClusterExpansionSpec(currentNodes []*models.EdgeNodeReference,
+	newNodesRaw []interface{}, client *client.VcfClient) (*models.EdgeClusterExpansionSpec, error) {
 	newNodes := getNewNodes(currentNodes, newNodesRaw)
 	nodeSpecs := make([]*models.NsxTEdgeNodeSpec, 0, len(newNodes))
 	spec := &models.EdgeClusterExpansionSpec{}

--- a/internal/nsx_edge_cluster/edge_cluster_operations.go
+++ b/internal/nsx_edge_cluster/edge_cluster_operations.go
@@ -285,12 +285,12 @@ func getComputeCluster(name string, client *client.VcfClient) (*models.Cluster, 
 	computeClusters := ok.Payload.Elements
 
 	if len(computeClusters) > 0 {
-		for _, v := range computeClusters {
-			if v.Name == name {
-				return v, nil
+		for _, cluster := range computeClusters {
+			if cluster.Name == name {
+				return cluster, nil
 			}
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("Cluster %s not found", name))
+	return nil, fmt.Errorf("cluster %s not found", name)
 }

--- a/internal/nsx_edge_cluster/edge_node_subresource.go
+++ b/internal/nsx_edge_cluster/edge_node_subresource.go
@@ -19,9 +19,17 @@ func EdgeNodeSchema() *schema.Resource {
 				Description:  "The name of the edge node",
 				ValidateFunc: validation.NoZeroValues,
 			},
+			"compute_cluster_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The name of the compute cluster",
+				ValidateFunc: validation.NoZeroValues,
+			},
 			"compute_cluster_id": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				Description:  "The id of the compute cluster",
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -145,7 +153,6 @@ func UplinkNetworkSchema() *schema.Resource {
 			},
 			"bgp_peer": {
 				Type:        schema.TypeList,
-				Required:    false,
 				Optional:    true,
 				Description: "List of BGP Peer configurations",
 				Elem:        BgpPeerSchema(),

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -457,9 +457,9 @@ func getDomain(name string, client *client.VcfClient) (*models.Domain, error) {
 	domainsList := ok.Payload.Elements
 
 	if len(domainsList) > 0 {
-		for _, v := range domainsList {
-			if v.Name == name {
-				return v, nil
+		for _, domain := range domainsList {
+			if domain.Name == name {
+				return domain, nil
 			}
 		}
 	}

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -464,5 +464,5 @@ func getDomain(name string, client *client.VcfClient) (*models.Domain, error) {
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("Domain %s not found", name))
+	return nil, fmt.Errorf("domain %s not found", name)
 }

--- a/internal/provider/resource_cluster_test.go
+++ b/internal/provider/resource_cluster_test.go
@@ -26,7 +26,7 @@ func TestAccResourceVcfClusterCreate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfClusterResourceConfig(
-					os.Getenv(constants.VcfTestDomainDataSourceId),
+					os.Getenv(constants.VcfTestDomainName),
 					os.Getenv(constants.VcfTestHost5Fqdn),
 					os.Getenv(constants.VcfTestHost5Pass),
 					os.Getenv(constants.VcfTestHost6Fqdn),
@@ -353,7 +353,7 @@ func testAccVcfClusterResourcеStretchTestConfig(name, stretchConfig string) str
 	)
 }
 
-func testAccVcfClusterResourceConfig(domainId, host1Fqdn, host1Pass, host2Fqdn, host2Pass,
+func testAccVcfClusterResourceConfig(domainName, host1Fqdn, host1Pass, host2Fqdn, host2Pass,
 	host3Fqdn, host3Pass, esxLicenseKey, vsanLicenseKey,
 	additionalCommissionHostConfig, additionalHostInClusterConfig string) string {
 	return fmt.Sprintf(`
@@ -408,7 +408,7 @@ func testAccVcfClusterResourceConfig(domainId, host1Fqdn, host1Pass, host2Fqdn, 
 	}
 	%s
 	resource "vcf_cluster" "cluster1" {
-		domain_id = %q
+		domain_name = %q
 		name = "sfo-m01-cl01"
 		host {
 			id = vcf_host.host1.id
@@ -484,7 +484,7 @@ func testAccVcfClusterResourceConfig(domainId, host1Fqdn, host1Pass, host2Fqdn, 
 		}
 		geneve_vlan_id = 3
 	}
-	`, host1Fqdn, host1Pass, host2Fqdn, host2Pass, host3Fqdn, host3Pass, additionalCommissionHostConfig, domainId,
+	`, host1Fqdn, host1Pass, host2Fqdn, host2Pass, host3Fqdn, host3Pass, additionalCommissionHostConfig, domainName,
 		esxLicenseKey, esxLicenseKey, esxLicenseKey, additionalHostInClusterConfig, vsanLicenseKey)
 }
 

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -157,7 +157,11 @@ func ResourceEdgeCluster() *schema.Resource {
 func resourceNsxEdgeClusterCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*api_client.SddcManagerClient).ApiClient
 
-	spec := nsx_edge_cluster.GetNsxEdgeClusterCreationSpec(data)
+	spec, err := nsx_edge_cluster.GetNsxEdgeClusterCreationSpec(data, client)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	validationErr := validateClusterCreationSpec(client, ctx, spec)
 
@@ -251,8 +255,12 @@ func resourceNsxEdgeClusterUpdate(ctx context.Context, data *schema.ResourceData
 		if len(oldNodes) < len(newNodes) {
 			operation := expansion
 			updateParams.EdgeClusterUpdateSpec.Operation = &operation
-			updateParams.EdgeClusterUpdateSpec.EdgeClusterExpansionSpec =
-				nsx_edge_cluster.GetNsxEdgeClusterExpansionSpec(edgeClusterOk.Payload.EdgeNodes, newNodes)
+			spec, err := nsx_edge_cluster.GetNsxEdgeClusterExpansionSpec(edgeClusterOk.Payload.EdgeNodes, newNodes, client)
+
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			updateParams.EdgeClusterUpdateSpec.EdgeClusterExpansionSpec = spec
 			tflog.Info(ctx, "Expanding edge cluster")
 		}
 

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -12,20 +12,21 @@ import (
 )
 
 const (
-	clusterName   = "testCluster1"
-	edgeNode1Name = "nsxt-edge-node-3.vrack.vsphere.local"
-	edgeNode2Name = "nsxt-edge-node-4.vrack.vsphere.local"
-	edgeNode3Name = "nsxt-edge-node-5.vrack.vsphere.local"
+	edgeClusterName = "testCluster1"
+	edgeNode1Name   = "nsxt-edge-node-3.vrack.vsphere.local"
+	edgeNode2Name   = "nsxt-edge-node-4.vrack.vsphere.local"
+	edgeNode3Name   = "nsxt-edge-node-5.vrack.vsphere.local"
 )
 
-func TestAccResourceEdgeCluster(t *testing.T) {
+// Same as the "full" test but will most optional inputs omitted
+func TestAccResourceEdgeCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			// Create
 			{
-				Config: getEdgeClusterConfigInitial(),
+				Config: getEdgeClusterConfigBasicInitial(),
 				Check: resource.ComposeTestCheckFunc(
 					getEdgeClusterChecks(2)...,
 				),
@@ -33,7 +34,7 @@ func TestAccResourceEdgeCluster(t *testing.T) {
 			// Update
 			// Expand the cluster with an additional node
 			{
-				Config: getEdgeClusterConfigExpansion(),
+				Config: getEdgeClusterConfigBasicExpansion(),
 				Check: resource.ComposeTestCheckFunc(
 					getEdgeClusterChecks(3)...,
 				),
@@ -41,7 +42,7 @@ func TestAccResourceEdgeCluster(t *testing.T) {
 			// Update
 			// Shrink the cluster to its original set of nodes
 			{
-				Config: getEdgeClusterConfigInitial(),
+				Config: getEdgeClusterConfigBasicInitial(),
 				Check: resource.ComposeTestCheckFunc(
 					getEdgeClusterChecks(2)...,
 				),
@@ -50,15 +51,47 @@ func TestAccResourceEdgeCluster(t *testing.T) {
 	})
 }
 
-func getEdgeClusterConfigInitial() string {
-	edgeNode1 := getEdgeNodeConfig(
+func TestAccResourceEdgeCluster_full(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: getEdgeClusterConfigFullInitial(),
+				Check: resource.ComposeTestCheckFunc(
+					getEdgeClusterChecks(2)...,
+				),
+			},
+			// Update
+			// Expand the cluster with an additional node
+			{
+				Config: getEdgeClusterConfigFullExpansion(),
+				Check: resource.ComposeTestCheckFunc(
+					getEdgeClusterChecks(3)...,
+				),
+			},
+			// Update
+			// Shrink the cluster to its original set of nodes
+			{
+				Config: getEdgeClusterConfigFullInitial(),
+				Check: resource.ComposeTestCheckFunc(
+					getEdgeClusterChecks(2)...,
+				),
+			},
+		},
+	})
+}
+
+func getEdgeClusterConfigFullInitial() string {
+	edgeNode1 := getEdgeNodeConfigFull(
 		edgeNode1Name,
 		"10.0.0.52/24",
 		"192.168.52.12/24",
 		"192.168.52.13/24",
 		"192.168.18.2/24",
 		"192.168.19.2/24")
-	edgeNode2 := getEdgeNodeConfig(
+	edgeNode2 := getEdgeNodeConfigFull(
 		edgeNode2Name,
 		"10.0.0.53/24",
 		"192.168.52.14/24",
@@ -84,7 +117,7 @@ func getEdgeClusterConfigInitial() string {
 			%s
 		}
 		`,
-		clusterName,
+		edgeClusterName,
 		os.Getenv(constants.VcfTestEdgeClusterRootPass),
 		os.Getenv(constants.VcfTestEdgeClusterAdminPass),
 		os.Getenv(constants.VcfTestEdgeClusterAuditPass),
@@ -92,22 +125,22 @@ func getEdgeClusterConfigInitial() string {
 		edgeNode2)
 }
 
-func getEdgeClusterConfigExpansion() string {
-	edgeNode1 := getEdgeNodeConfig(
+func getEdgeClusterConfigFullExpansion() string {
+	edgeNode1 := getEdgeNodeConfigFull(
 		edgeNode1Name,
 		"10.0.0.52/24",
 		"192.168.52.12/24",
 		"192.168.52.13/24",
 		"192.168.18.2/24",
 		"192.168.19.2/24")
-	edgeNode2 := getEdgeNodeConfig(
+	edgeNode2 := getEdgeNodeConfigFull(
 		edgeNode2Name,
 		"10.0.0.53/24",
 		"192.168.52.14/24",
 		"192.168.52.15/24",
 		"192.168.18.3/24",
 		"192.168.19.3/24")
-	edgeNode3 := getEdgeNodeConfig(
+	edgeNode3 := getEdgeNodeConfigFull(
 		edgeNode3Name,
 		"10.0.0.54/24",
 		"192.168.52.16/24",
@@ -134,7 +167,7 @@ func getEdgeClusterConfigExpansion() string {
 			%s
 		}
 		`,
-		clusterName,
+		edgeClusterName,
 		os.Getenv(constants.VcfTestEdgeClusterRootPass),
 		os.Getenv(constants.VcfTestEdgeClusterAdminPass),
 		os.Getenv(constants.VcfTestEdgeClusterAuditPass),
@@ -143,7 +176,90 @@ func getEdgeClusterConfigExpansion() string {
 		edgeNode3)
 }
 
-func getEdgeNodeConfig(name, ip, tep1, tep2, uplink1, uplink2 string) string {
+func getEdgeClusterConfigBasicInitial() string {
+	edgeNode1 := getEdgeNodeConfigBasic(
+		edgeNode1Name,
+		"10.0.0.52/24",
+		"192.168.52.12/24",
+		"192.168.52.13/24",
+		"192.168.18.2/24",
+		"192.168.19.2/24")
+	edgeNode2 := getEdgeNodeConfigBasic(
+		edgeNode2Name,
+		"10.0.0.53/24",
+		"192.168.52.14/24",
+		"192.168.52.15/24",
+		"192.168.18.3/24",
+		"192.168.19.3/24")
+
+	return fmt.Sprintf(`
+		resource "vcf_edge_cluster" "testCluster1" {
+			name      = %q
+			root_password = %q
+			admin_password = %q
+			audit_password = %q
+			form_factor = "MEDIUM"
+			profile_type = "DEFAULT"
+			mtu = 8940
+			%s
+			%s
+		}
+		`,
+		edgeClusterName,
+		os.Getenv(constants.VcfTestEdgeClusterRootPass),
+		os.Getenv(constants.VcfTestEdgeClusterAdminPass),
+		os.Getenv(constants.VcfTestEdgeClusterAuditPass),
+		edgeNode1,
+		edgeNode2)
+}
+
+func getEdgeClusterConfigBasicExpansion() string {
+	edgeNode1 := getEdgeNodeConfigBasic(
+		edgeNode1Name,
+		"10.0.0.52/24",
+		"192.168.52.12/24",
+		"192.168.52.13/24",
+		"192.168.18.2/24",
+		"192.168.19.2/24")
+	edgeNode2 := getEdgeNodeConfigBasic(
+		edgeNode2Name,
+		"10.0.0.53/24",
+		"192.168.52.14/24",
+		"192.168.52.15/24",
+		"192.168.18.3/24",
+		"192.168.19.3/24")
+	edgeNode3 := getEdgeNodeConfigBasic(
+		edgeNode3Name,
+		"10.0.0.54/24",
+		"192.168.52.16/24",
+		"192.168.52.17/24",
+		"192.168.18.6/24",
+		"192.168.19.6/24")
+
+	return fmt.Sprintf(`
+		resource "vcf_edge_cluster" "testCluster1" {
+			name      = %q
+			root_password = %q
+			admin_password = %q
+			audit_password = %q
+			form_factor = "MEDIUM"
+			mtu = 8940
+			asn = 65004
+			%s
+			%s
+			%s
+		}
+		`,
+		edgeClusterName,
+		os.Getenv(constants.VcfTestEdgeClusterRootPass),
+		os.Getenv(constants.VcfTestEdgeClusterAdminPass),
+		os.Getenv(constants.VcfTestEdgeClusterAuditPass),
+		edgeNode1,
+		edgeNode2,
+		edgeNode3)
+}
+
+func getEdgeNodeConfigFull(name, ip, tep1, tep2, uplink1, uplink2 string) string {
 	return fmt.Sprintf(`
 		edge_node {
 			name = %q
@@ -182,6 +298,45 @@ func getEdgeNodeConfig(name, ip, tep1, tep2, uplink1, uplink2 string) string {
 		`,
 		name,
 		os.Getenv(constants.VcfTestComputeClusterId),
+		os.Getenv(constants.VcfTestEdgeNodeRootPass),
+		os.Getenv(constants.VcfTestEdgeNodeAdminPass),
+		os.Getenv(constants.VcfTestEdgeNodeAuditPass),
+		ip,
+		tep1,
+		tep2,
+		uplink1,
+		uplink2)
+}
+
+func getEdgeNodeConfigBasic(name, ip, tep1, tep2, uplink1, uplink2 string) string {
+	return fmt.Sprintf(`
+		edge_node {
+			name = %q
+			compute_cluster_name = %q
+			root_password = %q
+			admin_password = %q
+			audit_password = %q
+			management_ip = %q
+			management_gateway = "10.0.0.250"
+			tep_gateway = "192.168.52.1"
+			tep1_ip = %q
+			tep2_ip = %q
+			tep_vlan = 1252
+			inter_rack_cluster = false
+
+			uplink {
+				vlan = 2083
+				interface_ip = %q
+			}
+
+			uplink {
+				vlan = 2084
+				interface_ip = %q
+			}
+		}
+		`,
+		name,
+		os.Getenv(constants.VcfTestComputeClusterName),
 		os.Getenv(constants.VcfTestEdgeNodeRootPass),
 		os.Getenv(constants.VcfTestEdgeNodeAdminPass),
 		os.Getenv(constants.VcfTestEdgeNodeAuditPass),

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -18,7 +18,7 @@ const (
 	edgeNode3Name   = "nsxt-edge-node-5.vrack.vsphere.local"
 )
 
-// Same as the "full" test but will most optional inputs omitted
+// same as the "full" test but will most optional inputs omitted.
 func TestAccResourceEdgeCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -239,12 +238,12 @@ func getNetworkPool(name string, client *client.VcfClient) (*models.NetworkPool,
 	networkPools := ok.Payload.Elements
 
 	if len(networkPools) > 0 {
-		for _, v := range networkPools {
-			if v.Name == name {
-				return v, nil
+		for _, pool := range networkPools {
+			if pool.Name == name {
+				return pool, nil
 			}
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("Network pool %s not found", name))
+	return nil, fmt.Errorf("network pool %s not found", name)
 }

--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -110,7 +111,13 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	if networkPoolId, ok := d.GetOk("network_pool_id"); ok {
 		networkPoolIdStr := networkPoolId.(string)
 		commissionSpec.NetworkPoolID = &networkPoolIdStr
-	} else if networkPoolName, ok := d.GetOk("network_pool_name"); ok {
+	}
+
+	if networkPoolName, ok := d.GetOk("network_pool_name"); ok {
+		if commissionSpec.NetworkPoolID != nil {
+			return diag.FromErr(errors.New("you cannot set network_pool_id and network_pool_name at the same time"))
+		}
+
 		networkPool, err := getNetworkPool(networkPoolName.(string), apiClient)
 
 		if err != nil {

--- a/internal/provider/resource_host_test.go
+++ b/internal/provider/resource_host_test.go
@@ -47,7 +47,7 @@ func TestAccResourceVcfHost_networkPoolName(t *testing.T) {
 		CheckDestroy:      testCheckVcfHostDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVcfHostConfig_networkPoolName(
+				Config: testAccVcfHostConfigNetworkPoolName(
 					os.Getenv(constants.VcfTestHost1Fqdn),
 					os.Getenv(constants.VcfTestHost1Pass)),
 				Check: resource.ComposeTestCheckFunc(
@@ -97,7 +97,7 @@ func testAccVcfHostConfig(hostFqdn, hostSshPassword string) string {
 	}`, hostFqdn, hostSshPassword)
 }
 
-func testAccVcfHostConfig_networkPoolName(hostFqdn, hostSshPassword string) string {
+func testAccVcfHostConfigNetworkPoolName(hostFqdn, hostSshPassword string) string {
 	return fmt.Sprintf(`
 	resource "vcf_network_pool" "eng_pool" {
 		name    = "engineering-pool"
@@ -124,7 +124,7 @@ func testAccVcfHostConfig_networkPoolName(hostFqdn, hostSshPassword string) stri
 			  start = "192.168.9.5"
 			  end   = "192.168.9.50"
 			}
-		  }
+		}
 	}
 
 	resource "vcf_host" "host1" {

--- a/internal/provider/resource_host_test.go
+++ b/internal/provider/resource_host_test.go
@@ -39,7 +39,7 @@ func TestAccResourceVcfHost(t *testing.T) {
 	})
 }
 
-// Verifies host commissioning when the network pool is specified by its name
+// Verifies host commissioning when the network pool is specified by its name.
 func TestAccResourceVcfHost_networkPoolName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },


### PR DESCRIPTION
**Summary of Pull Request**

Accepting entity identifiers as inputs is convenient when these entities are managed by Terraform but not so much when they are created externally.

I'm modifying the resource schemas for hosts, clusters and edge clusters so that they accept network pool names, domain names and compute cluster names respectively in addition to their IDs.

Setting values for both attributes at the same time is not allowed and will result in an explicit error.

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #91
Closes #191
Closes #193

**Test and Documentation Coverage**

Since this change introduces new API calls I've added additional test cases or modified existing ones where appropriate
`TestAccResourceVcfClusterCreate` -> modified to use domain name. There are other tests for this resource that still use the ID.
`TestAccResourceEdgeCluster_basic` -> new test that uses the new attribute for compute cluster name. This one doubles as a test for the minimum set of inputs for this resource.
`TestAccResourceVcfHost_networkPoolName` -> new test 

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
