### PR TITLE
feat: add `fqdn` parameter for `r/csr`

### DIFF
--- a/docs/resources/csr.md
+++ b/docs/resources/csr.md
@@ -23,11 +23,12 @@ external or internal CA.
 - `country` (String) ISO 3166 country code where company is legally registered
 - `domain_id` (String) Domain Id or Name for which the CSRs should be generated
 - `email` (String) Contact email address
+- `fqdn` (String) FQDN of the resource
 - `key_size` (Number) Certificate public key size. One among: 2048, 3072, 4096
 - `locality` (String) The city or locality where company is legally registered
 - `organization` (String) The name under which your company is known. The listed organization must be the legal registrant of the domain name in the certificate request.
 - `organization_unit` (String) Organization with which the certificate is associated
-- `resource` (String) Resources for which the CSRs are to be generated. One among: SDDC_MANAGER, VCENTER, NSX_MANAGER, NSXT_MANAGER, VROPS, VRSLCM, VXRAIL_MANAGER
+- `resource` (String) Resources for which the CSRs are to be generated. One among: SDDC_MANAGER, PSC, VCENTER, NSX_MANAGER, NSXT_MANAGER, VROPS, VRSLCM, VXRAIL_MANAGER
 - `state` (String) Full name (do not abbreviate) of the state, province, region, or territory where your company is legally registered.
 
 ### Optional

--- a/internal/certificates/certificate_operations.go
+++ b/internal/certificates/certificate_operations.go
@@ -1,48 +1,19 @@
-// Copyright 2023 Broadcom. All Rights Reserved.
+// Copyright 2023-2024 Broadcom. All Rights Reserved.
 // SPDX-License-Identifier: MPL-2.0
 
 package certificates
 
 import (
 	"context"
-	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/vmware/terraform-provider-vcf/internal/api_client"
 	"github.com/vmware/terraform-provider-vcf/internal/constants"
 	validationutils "github.com/vmware/terraform-provider-vcf/internal/validation"
-	"github.com/vmware/vcf-sdk-go/client"
 	vcfclient "github.com/vmware/vcf-sdk-go/client"
 	"github.com/vmware/vcf-sdk-go/client/certificates"
-	"github.com/vmware/vcf-sdk-go/client/domains"
 	"github.com/vmware/vcf-sdk-go/models"
-	"strings"
 	"time"
 )
-
-func GetFqdnOfResourceTypeInDomain(ctx context.Context, domainId, resourceType string, apiClient *client.VcfClient) (*string, error) {
-	if apiClient == nil || len(resourceType) < 1 || len(domainId) < 1 {
-		return nil, nil
-	}
-
-	endpointsParams := domains.NewGetDomainEndpointsParamsWithContext(ctx).
-		WithTimeout(constants.DefaultVcfApiCallTimeout).WithID(domainId)
-
-	endpointsResult, err := apiClient.Domains.GetDomainEndpoints(endpointsParams)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, endpoint := range endpointsResult.Payload.Elements {
-		if resourceType == *endpoint.Type {
-			result := *endpoint.URL
-			if strings.Contains(result, "https://") {
-				result = strings.ReplaceAll(result, "https://", "")
-			}
-			return &result, nil
-		}
-	}
-	return nil, nil
-}
 
 func ValidateResourceCertificates(ctx context.Context, client *vcfclient.VcfClient,
 	domainId string, resourceCertificateSpecs []*models.ResourceCertificateSpec) diag.Diagnostics {
@@ -66,7 +37,7 @@ func ValidateResourceCertificates(ctx context.Context, client *vcfclient.VcfClie
 		return validationutils.ConvertCertificateValidationsResultToDiag(validationResponse)
 	}
 	validationId := validationResponse.ValidationID
-	// Wait for certificate validation to fisnish
+	// Wait for certificate validation to finish
 	if !validationutils.HasCertificateValidationFinished(validationResponse) {
 		for {
 			getResourceCertificatesValidationResultParams := certificates.NewGetResourceCertificatesValidationByIDParams().
@@ -95,15 +66,7 @@ func ValidateResourceCertificates(ctx context.Context, client *vcfclient.VcfClie
 }
 
 func GetCertificateForResourceInDomain(ctx context.Context, client *vcfclient.VcfClient,
-	domainId, resourceType string) (*models.Certificate, error) {
-	resourceFqdn, err := GetFqdnOfResourceTypeInDomain(ctx, domainId, resourceType, client)
-	if err != nil {
-		return nil, err
-	}
-	if resourceFqdn == nil {
-		return nil, fmt.Errorf("could not determine FQDN for resourceType %s in domain %s", resourceType, domainId)
-	}
-
+	domainId, resourceFqdn string) (*models.Certificate, error) {
 	viewCertificatesParams := certificates.NewGetCertificatesByDomainParamsWithContext(ctx).
 		WithTimeout(constants.DefaultVcfApiCallTimeout)
 	viewCertificatesParams.ID = domainId
@@ -115,7 +78,7 @@ func GetCertificateForResourceInDomain(ctx context.Context, client *vcfclient.Vc
 
 	allCertsForDomain := certificatesResponse.Payload.Elements
 	for _, cert := range allCertsForDomain {
-		if cert.IssuedTo != nil && *cert.IssuedTo == *resourceFqdn {
+		if cert.IssuedTo != nil && *cert.IssuedTo == resourceFqdn {
 			return cert, nil
 		}
 	}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -170,6 +170,15 @@ const (
 
 	// VcfTestComputeClusterName the display name of the compute cluster that will contain the edge nodes.
 	VcfTestComputeClusterName = "VCF_TEST_COMPUTE_CLUSTER_NAME"
+
+	// VcfTestVcenterFqdn the FQDN of the vcenter server.
+	VcfTestVcenterFqdn = "VCF_TEST_VCENTER_FQDN"
+
+	// VcfTestSddcManagerFqdn the FQDN of the SDDC manager.
+	VcfTestSddcManagerFqdn = "VCF_TEST_SDDC_MANAGER_FQDN"
+
+	// VcfTestNsxManagerFqdn the FQDN of the NSX manager.
+	VcfTestNsxManagerFqdn = "VCF_TEST_NSX_MANAGER_FQDN"
 )
 
 func GetIso3166CountryCodes() []string {

--- a/internal/provider/resource_certificate_test.go
+++ b/internal/provider/resource_certificate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Broadcom. All Rights Reserved.
+// Copyright 2023-2024 Broadcom. All Rights Reserved.
 // SPDX-License-Identifier: MPL-2.0
 
 package provider
@@ -11,8 +11,8 @@ import (
 	"testing"
 )
 
-func TestAccResourceVcfResourceCertificate(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+func TestAccResourceVcfResourceCertificate_vCenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccVcfCertificateAuthorityPreCheck(t)
@@ -24,7 +24,9 @@ func TestAccResourceVcfResourceCertificate(t *testing.T) {
 					os.Getenv(constants.VcfTestDomainDataSourceId),
 					os.Getenv(constants.VcfTestMsftCaServerUrl),
 					os.Getenv(constants.VcfTestMsftCaUser),
-					os.Getenv(constants.VcfTestMsftCaSecret)),
+					os.Getenv(constants.VcfTestMsftCaSecret),
+					"VCENTER",
+					os.Getenv(constants.VcfTestVcenterFqdn)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.issued_by"),
 					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.issued_to"),
@@ -49,7 +51,87 @@ func TestAccResourceVcfResourceCertificate(t *testing.T) {
 	})
 }
 
-func testAccVcfResourceCertificate(domainID, msftCaServerUrl, msftCaUser, msftCaSecret string) string {
+func TestAccResourceVcfResourceCertificate_sddcManager(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccVcfCertificateAuthorityPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVcfResourceCertificate(
+					os.Getenv(constants.VcfTestDomainDataSourceId),
+					os.Getenv(constants.VcfTestMsftCaServerUrl),
+					os.Getenv(constants.VcfTestMsftCaUser),
+					os.Getenv(constants.VcfTestMsftCaSecret),
+					"SDDC_MANAGER",
+					os.Getenv(constants.VcfTestSddcManagerFqdn)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.issued_by"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.issued_to"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.expiration_status"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.certificate_error"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.key_size"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.not_after"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.not_before"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.pem_encoded"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.public_key"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.public_key_algorithm"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.serial_number"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.signature_algorithm"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.subject"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.subject_alternative_name.#"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.thumbprint"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.thumbprint_algorithm"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.version"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.number_of_days_to_expire")),
+			},
+		},
+	})
+}
+
+func TestAccResourceVcfResourceCertificate_nsx(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccVcfCertificateAuthorityPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVcfResourceCertificate(
+					os.Getenv(constants.VcfTestDomainDataSourceId),
+					os.Getenv(constants.VcfTestMsftCaServerUrl),
+					os.Getenv(constants.VcfTestMsftCaUser),
+					os.Getenv(constants.VcfTestMsftCaSecret),
+					"NSXT_MANAGER",
+					os.Getenv(constants.VcfTestNsxManagerFqdn)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.issued_by"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.issued_to"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.expiration_status"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.certificate_error"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.key_size"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.not_after"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.not_before"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.pem_encoded"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.public_key"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.public_key_algorithm"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.serial_number"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.signature_algorithm"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.subject"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.subject_alternative_name.#"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.thumbprint"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.thumbprint_algorithm"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.version"),
+					resource.TestCheckResourceAttrSet("vcf_certificate.vcenter_cert", "certificate.0.number_of_days_to_expire")),
+			},
+		},
+	})
+}
+
+func testAccVcfResourceCertificate(domainID, msftCaServerUrl, msftCaUser, msftCaSecret, resource, fqdn string) string {
 	return fmt.Sprintf(`
 	resource "vcf_certificate_authority" "ca" {
   		microsoft {
@@ -69,7 +151,8 @@ func testAccVcfResourceCertificate(domainID, msftCaServerUrl, msftCaUser, msftCa
 		state = "Sofia-grad"
 		organization = "VMware Inc."
 		organization_unit = "VCF"
-		resource = "VCENTER"
+		resource = %q
+		fqdn = %q
 	}
 
 
@@ -82,5 +165,7 @@ func testAccVcfResourceCertificate(domainID, msftCaServerUrl, msftCaUser, msftCa
 		msftCaSecret,
 		msftCaServerUrl,
 		domainID,
+		resource,
+		fqdn,
 	)
 }

--- a/internal/provider/resource_csr_test.go
+++ b/internal/provider/resource_csr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Broadcom. All Rights Reserved.
+// Copyright 2023-2024 Broadcom. All Rights Reserved.
 // SPDX-License-Identifier: MPL-2.0
 
 package provider
@@ -11,15 +11,15 @@ import (
 	"testing"
 )
 
-func TestAccResourceVcfCsr(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+func TestAccResourceVcfCsr_vCenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId)),
+				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId), "VCENTER", os.Getenv(constants.VcfTestVcenterFqdn)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.csr_pem"),
 					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.csr_string"),
@@ -29,7 +29,43 @@ func TestAccResourceVcfCsr(t *testing.T) {
 	})
 }
 
-func testAccVcfCsrConfig(domainID string) string {
+func TestAccResourceVcfCsr_sddcManager(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId), "SDDC_MANAGER", os.Getenv(constants.VcfTestSddcManagerFqdn)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.csr_pem"),
+					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.csr_string"),
+					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.resource.0.fqdn")),
+			},
+		},
+	})
+}
+
+func TestAccResourceVcfCsr_nsxManager(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId), "NSXT_MANAGER", os.Getenv(constants.VcfTestNsxManagerFqdn)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.csr_pem"),
+					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.csr_string"),
+					resource.TestCheckResourceAttrSet("vcf_csr.csr1", "csr.0.resource.0.fqdn")),
+			},
+		},
+	})
+}
+
+func testAccVcfCsrConfig(domainID, resource, fqdn string) string {
 	return fmt.Sprintf(`
 	resource "vcf_csr" "csr1" {
   		domain_id = %q
@@ -40,8 +76,9 @@ func testAccVcfCsrConfig(domainID string) string {
 		state = "Sofia-grad"
 		organization = "VMware Inc."
 		organization_unit = "VCF"
-		resource = "VCENTER"
+		resource = %q
+		fqdn = %q
 	}`,
-		domainID,
+		domainID, resource, fqdn,
 	)
 }

--- a/internal/provider/resource_external_certificate.go
+++ b/internal/provider/resource_external_certificate.go
@@ -78,20 +78,13 @@ func resourceResourceExternalCertificateCreate(ctx context.Context, data *schema
 
 	csrID := data.Get("csr_id").(string)
 	csrIdComponents := strings.Split(csrID, ":")
-	if len(csrIdComponents) != 4 {
+	if len(csrIdComponents) != 5 {
 		return diag.FromErr(fmt.Errorf("CSR ID invalid"))
 	}
 
 	domainID := csrIdComponents[1]
 	resourceType := csrIdComponents[2]
-
-	resourceFqdn, err := certificates.GetFqdnOfResourceTypeInDomain(ctx, domainID, resourceType, apiClient)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if resourceFqdn == nil {
-		return diag.FromErr(fmt.Errorf("could not determine FQDN for resourceType %s in domain %s", resourceType, domainID))
-	}
+	resourceFqdn := csrIdComponents[3]
 
 	caCertificate := data.Get("ca_certificate").(string)
 	certificateChain := data.Get("certificate_chain").(string)
@@ -101,13 +94,13 @@ func resourceResourceExternalCertificateCreate(ctx context.Context, data *schema
 
 	if !validation_utils.IsEmpty(resourceCertificate) && !validation_utils.IsEmpty(caCertificate) {
 		resourceCertificateSpec = &models.ResourceCertificateSpec{
-			ResourceFqdn:        *resourceFqdn,
+			ResourceFqdn:        resourceFqdn,
 			CaCertificate:       caCertificate,
 			ResourceCertificate: resourceCertificate,
 		}
 	} else if !validation_utils.IsEmpty(certificateChain) {
 		resourceCertificateSpec = &models.ResourceCertificateSpec{
-			ResourceFqdn:     *resourceFqdn,
+			ResourceFqdn:     resourceFqdn,
 			CertificateChain: certificateChain,
 		}
 	} else {
@@ -149,7 +142,7 @@ func resourceResourceExternalCertificateRead(ctx context.Context, data *schema.R
 
 	csrID := data.Get("csr_id").(string)
 	csrIdComponents := strings.Split(csrID, ":")
-	if len(csrIdComponents) != 4 {
+	if len(csrIdComponents) != 5 {
 		return diag.FromErr(fmt.Errorf("CSR ID invalid"))
 	}
 


### PR DESCRIPTION
**Summary of Pull Request**

The resource for generating certificate signing requests accepts a resource type and automatically determines the correct FQDN for the request. This only works for resources of type VCENTER due to a limitation in the underlying API.

To resolve this we have to switch to an API andpoint that returns the full set of possible resources. Unfortunately in 5.1.1 this is not possible because this endpoint is not public.
A public endpoint will be available in an upcoming VCF release.

But even if we wait and try to fix this later we would encounter another problem. Some resources can have multiple instances (NSX for example). It would not be possible for the provider to determine which FQDN to use.

The only complete solution would be to explicitly provide the FQDN for the CSR as an input attribute of the resource.

**Type of Pull Request**

- [X] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #195

**Test and Documentation Coverage**

I have added additional test cases for `vcf_csr` and `vcf_certificate`

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [X] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

The identifiers for existing CSR resources will no longer be valid.
User's will have to regenerate their CSRs.
