### PR TITLE
fix: esa_enabled for r/vcf_instance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.9.0
-	github.com/vmware/vcf-sdk-go v0.3.2
+	github.com/vmware/vcf-sdk-go v0.3.3
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 )
 

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/vmware/vcf-sdk-go v0.3.2 h1:WhmIs7Xx4NePg2/VgaFBBfjZ7NG0W9W8+JmvWey59HU=
 github.com/vmware/vcf-sdk-go v0.3.2/go.mod h1:EXM19ZwD2qmvMVSvgUzcnT7dSTCq3lzv84ErrFPZm1Q=
+github.com/vmware/vcf-sdk-go v0.3.3 h1:4jGpDnZUZV2CmsUFiOOi1+HFTOfFy01WukfpOJEwVE8=
+github.com/vmware/vcf-sdk-go v0.3.3/go.mod h1:EXM19ZwD2qmvMVSvgUzcnT7dSTCq3lzv84ErrFPZm1Q=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/sddc/sddc_vsan_subresource.go
+++ b/internal/sddc/sddc_vsan_subresource.go
@@ -6,7 +6,6 @@ package sddc
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	utils "github.com/vmware/terraform-provider-vcf/internal/resource_utils"
-	validationutils "github.com/vmware/terraform-provider-vcf/internal/validation"
 	"github.com/vmware/vcf-sdk-go/models"
 )
 
@@ -56,18 +55,14 @@ func GetVsanSpecFromSchema(rawData []interface{}) *models.VSANSpec {
 	hclFile := data["hcl_file"].(string)
 	license := data["license"].(string)
 	vsanDedup := data["vsan_dedup"].(bool)
+	esaEnabled := data["esa_enabled"].(bool)
 
 	vsanSpecBinding := &models.VSANSpec{
 		DatastoreName: utils.ToStringPointer(datastoreName),
 		HclFile:       hclFile,
 		LicenseFile:   license,
 		VSANDedup:     vsanDedup,
-	}
-
-	if esaEnabled, ok := data["esa_enabled"]; ok && !validationutils.IsEmpty(esaEnabled) {
-		value := esaEnabled.(bool)
-		esaConfig := models.VSANEsaConfig{Enabled: value}
-		vsanSpecBinding.EsaConfig = &esaConfig
+		EsaConfig:     &models.VSANEsaConfig{Enabled: &esaEnabled},
 	}
 
 	return vsanSpecBinding


### PR DESCRIPTION
**Summary of Pull Request**

Support for configuring vSAN in ESA mode was added in VCF 5.
It was implemented as an optional attribute with https://github.com/vmware/terraform-provider-vcf/pull/190

The flaw in my original PR is that the new property is optional and since it is marked with "omitempty" it is skipped during serialization whenever it is set to false.

I've made a change to the SDK that marks the property as required. The containing structure is still optional.

This means that `esa_enabled` will now behave as follows:
* When `esa_enabled = true` the `VSANEsaConfig` structure will be set and vSAN will be configured in ESA mode
* When `esa_enabled = false` the `VSANEsaConfig` structure will be set and vSAN will be configured in normal mode
* When `esa_enabled` is not set  the `VSANEsaConfig` structure will be set and vSAN will be configured in normal mode

This will ensure that
1. ESA is optonal
2. The default mode is non-ESA

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

Ran TestAccResourceVcfSddcBasic by modifying the configuration for the 3 scenarios listed above - esa_enabled set to true, false and to nothing.

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
