### PR TITLE
add missed vrops resourcetype for credentials

### DIFF
--- a/internal/credentials/constants.go
+++ b/internal/credentials/constants.go
@@ -21,6 +21,7 @@ const (
 	ResourceTypeVxrailManager = "VXRAIL_MANAGER"
 	ResourceTypeNsxAlb        = "NSX_ALB"
 	ResourceTypeBackup        = "BACKUP"
+	ResourceTypeVrops         = "VROPS"
 )
 
 const (
@@ -61,5 +62,6 @@ func AllResourceTypes() []string {
 		ResourceTypeWsa,
 		ResourceTypeVrslcm,
 		ResourceTypeVxrailManager,
+		ResourceTypeVrops,
 	}
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**
This pull request is to add the missed vrops resourceType definition in resource/credentials
<!---->


**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  The PR is the related issue 
-->

Issue Number: [218](https://github.com/vmware/terraform-provider-vcf/issues/218)

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
