### PR TITLE
fix: bootstrap in muxed mode during testing

### DIFF
--- a/internal/provider/data_credentials_test.go
+++ b/internal/provider/data_credentials_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestAccDataSourceCredentialsAll(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccDataSourceCredentialsAll(),
 			Check:  resource.TestCheckResourceAttrSet("data.vcf_credentials.creds", "credentials.#"),
@@ -23,8 +23,8 @@ func TestAccDataSourceCredentialsAll(t *testing.T) {
 
 func TestAccDataSourceCredentials_VC(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccDataSourceCredentialsVc(),
 			Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/data_network_pool.go
+++ b/internal/provider/data_network_pool.go
@@ -104,7 +104,7 @@ func dataSourceNetworkPoolRead(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(networkPool.ID)
 	_ = d.Set("name", networkPool.Name)
-	_ = d.Set("networks", flattenNetworks(networkPool.Networks))
+	_ = d.Set("network", flattenNetworks(networkPool.Networks))
 
 	return nil
 }

--- a/internal/provider/data_network_pool_test.go
+++ b/internal/provider/data_network_pool_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccDataSourceVcfNetworkPool(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVcfNetworkPoolConfig(constants.VcfTestNetworkPoolName),

--- a/internal/provider/data_source_cluster_test.go
+++ b/internal/provider/data_source_cluster_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestAccDataSourceVcfCluster(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfClusterDataSourceConfig(

--- a/internal/provider/data_source_domain_test.go
+++ b/internal/provider/data_source_domain_test.go
@@ -64,9 +64,9 @@ func TestAccDataSourceVcfDomainById(t *testing.T) {
 	config := testAccVcfDomainDataSourceConfigById(os.Getenv(constants.VcfTestDomainDataSourceId))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		Steps:             testAccVcfDomainDataSourceSteps(config),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		Steps:                    testAccVcfDomainDataSourceSteps(config),
 	})
 }
 
@@ -74,8 +74,8 @@ func TestAccDataSourceVcfDomainByName(t *testing.T) {
 	config := testAccVcfDomainDataSourceConfigByName(os.Getenv(constants.VcfTestDomainDataSourceName))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		Steps:             testAccVcfDomainDataSourceSteps(config),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		Steps:                    testAccVcfDomainDataSourceSteps(config),
 	})
 }

--- a/internal/provider/resource_ceip_test.go
+++ b/internal/provider/resource_ceip_test.go
@@ -17,9 +17,9 @@ import (
 
 func TestAccResourceVcfCeip(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfCeipDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfCeipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfCeip(),

--- a/internal/provider/resource_certificate_authority_test.go
+++ b/internal/provider/resource_certificate_authority_test.go
@@ -27,7 +27,7 @@ func TestAccResourceVcfCertificateAuthority(t *testing.T) {
 			testAccVcfCertificateAuthorityPreCheck(t)
 		},
 		ProtoV6ProviderFactories: muxedFactories(),
-		CheckDestroy:      testVerifyVcfCertificateAuthorityDestroy,
+		CheckDestroy:             testVerifyVcfCertificateAuthorityDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfCertificateAuthorityMsft(),

--- a/internal/provider/resource_certificate_authority_test.go
+++ b/internal/provider/resource_certificate_authority_test.go
@@ -26,7 +26,7 @@ func TestAccResourceVcfCertificateAuthority(t *testing.T) {
 			testAccPreCheck(t)
 			testAccVcfCertificateAuthorityPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		CheckDestroy:      testVerifyVcfCertificateAuthorityDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_certificate_test.go
+++ b/internal/provider/resource_certificate_test.go
@@ -20,7 +20,7 @@ func TestAccResourceVcfResourceCertificate_vCenter(t *testing.T) {
 			testAccPreCheck(t)
 			testAccVcfCertificateAuthorityPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfResourceCertificate(
@@ -60,7 +60,7 @@ func TestAccResourceVcfResourceCertificate_sddcManager(t *testing.T) {
 			testAccPreCheck(t)
 			testAccVcfCertificateAuthorityPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfResourceCertificate(
@@ -100,7 +100,7 @@ func TestAccResourceVcfResourceCertificate_nsx(t *testing.T) {
 			testAccPreCheck(t)
 			testAccVcfCertificateAuthorityPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfResourceCertificate(

--- a/internal/provider/resource_cluster_personality_test.go
+++ b/internal/provider/resource_cluster_personality_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestAccClusterPersonality_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPersonalityPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testAccPersonalityPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: getClusterPersonalityConfig(),

--- a/internal/provider/resource_cluster_test.go
+++ b/internal/provider/resource_cluster_test.go
@@ -23,9 +23,9 @@ import (
 
 func TestAccResourceVcfClusterCreate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfClusterDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfClusterResourceConfig(
@@ -57,9 +57,9 @@ func TestAccResourceVcfClusterCreate(t *testing.T) {
 
 func TestAccResourceVcfClusterStretchUnstretch(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfClusterDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfClusterResourcеStretchTestConfig(
@@ -94,9 +94,9 @@ func TestAccResourceVcfClusterStretchUnstretch(t *testing.T) {
 
 func TestAccResourceVcfClusterFull(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfClusterDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfClusterResourceConfig(

--- a/internal/provider/resource_credentials_auto_rotate_policy_test.go
+++ b/internal/provider/resource_credentials_auto_rotate_policy_test.go
@@ -20,7 +20,7 @@ func TestAccResourceAutorotatePolicy_resourceId(t *testing.T) {
 	timeAfter := time.Now().AddDate(0, 0, rotateDays)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccAutorotatePolicyResourceIdConfig(rotateDays),
 			Check: resource.TestCheckResourceAttrWith("vcf_credentials_auto_rotate_policy.vc_0_autorotate", "auto_rotate_next_schedule", func(value string) error {

--- a/internal/provider/resource_credentials_auto_rotate_policy_test.go
+++ b/internal/provider/resource_credentials_auto_rotate_policy_test.go
@@ -19,7 +19,7 @@ func TestAccResourceAutorotatePolicy_resourceId(t *testing.T) {
 	rotateDays := acctest.RandIntRange(credentials.AutoRotateDaysMin, credentials.AutorotateDaysMax)
 	timeAfter := time.Now().AddDate(0, 0, rotateDays)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
+		PreCheck:                 func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
 		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccAutorotatePolicyResourceIdConfig(rotateDays),

--- a/internal/provider/resource_credentials_password_rotate_test.go
+++ b/internal/provider/resource_credentials_password_rotate_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccCredentialsResourcePasswordRotate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
+		PreCheck:                 func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
 		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccResourceCredentialsPasswordRotateConfig(),

--- a/internal/provider/resource_credentials_password_rotate_test.go
+++ b/internal/provider/resource_credentials_password_rotate_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccCredentialsResourcePasswordRotate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccResourceCredentialsPasswordRotateConfig(),
 			Check:  testAccResourceCredentialsPasswordRotateCheck,

--- a/internal/provider/resource_credentials_password_update_test.go
+++ b/internal/provider/resource_credentials_password_update_test.go
@@ -17,8 +17,8 @@ func TestAccCredentialsResourcePasswordUpdate(t *testing.T) {
 	newPassword := fmt.Sprintf("%s$1A", acctest.RandString(7))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testAccSDDCManagerOrCloudBuilderPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{{
 			Config: testAccResourceCredentialsPasswordUpdateConfig(newPassword),
 			Check:  resource.TestCheckResourceAttr("data.vcf_credentials.esx_creds", "credentials.0.password", newPassword),

--- a/internal/provider/resource_csr_test.go
+++ b/internal/provider/resource_csr_test.go
@@ -19,7 +19,7 @@ func TestAccResourceVcfCsr_vCenter(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId), "VCENTER", os.Getenv(constants.VcfTestVcenterFqdn)),
@@ -37,7 +37,7 @@ func TestAccResourceVcfCsr_sddcManager(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId), "SDDC_MANAGER", os.Getenv(constants.VcfTestSddcManagerFqdn)),
@@ -55,7 +55,7 @@ func TestAccResourceVcfCsr_nsxManager(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfCsrConfig(os.Getenv(constants.VcfTestDomainDataSourceId), "NSXT_MANAGER", os.Getenv(constants.VcfTestNsxManagerFqdn)),

--- a/internal/provider/resource_domain_test.go
+++ b/internal/provider/resource_domain_test.go
@@ -22,9 +22,9 @@ import (
 
 func TestAccResourceVcfDomainCreate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfDomainDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfDomainDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Initial config: 1 network pool, 3 commissioned hosts, Domain with cluster with those 3 hosts
@@ -76,9 +76,9 @@ func TestAccResourceVcfDomainCreate(t *testing.T) {
 
 func TestAccResourceVcfDomainFull(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfDomainDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfDomainDestroy,
 		Steps: []resource.TestStep{
 			{
 				// Initial config: 1 network pool, 3 commissioned hosts, Domain with cluster with those 3 hosts

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -25,7 +25,7 @@ const (
 func TestAccResourceEdgeCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			// Create
 			{
@@ -57,7 +57,7 @@ func TestAccResourceEdgeCluster_basic(t *testing.T) {
 func TestAccResourceEdgeCluster_full(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			// Create
 			{

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -24,7 +24,7 @@ const (
 // same as the "full" test but will most optional inputs omitted.
 func TestAccResourceEdgeCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			// Create
@@ -56,7 +56,7 @@ func TestAccResourceEdgeCluster_basic(t *testing.T) {
 
 func TestAccResourceEdgeCluster_full(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			// Create

--- a/internal/provider/resource_external_certificate_test.go
+++ b/internal/provider/resource_external_certificate_test.go
@@ -26,7 +26,7 @@ func TestAccResourceVcfResourceExternalCertificate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccVcfResourceExternalCertificatePreCheck(t)
 		},
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfResourceExternalCertificate(

--- a/internal/provider/resource_host_test.go
+++ b/internal/provider/resource_host_test.go
@@ -19,9 +19,9 @@ import (
 
 func TestAccResourceVcfHost(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfHostDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfHostDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfHostConfig(
@@ -45,9 +45,9 @@ func TestAccResourceVcfHost(t *testing.T) {
 // Verifies host commissioning when the network pool is specified by its name.
 func TestAccResourceVcfHost_networkPoolName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testCheckVcfHostDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
+		CheckDestroy:             testCheckVcfHostDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfHostConfigNetworkPoolName(

--- a/internal/provider/resource_network_pool_test.go
+++ b/internal/provider/resource_network_pool_test.go
@@ -18,7 +18,7 @@ import (
 func TestAccResourceVcfNetworkPool(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		ProtoV6ProviderFactories: muxedFactories(),
 		CheckDestroy:             testCheckVcfNetworkPoolDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -22,9 +22,9 @@ const (
 
 func TestAccResourceVcfUser(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: muxedFactories(),
-		CheckDestroy:      testCheckVcfUserDestroy,
+		CheckDestroy:             testCheckVcfUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVcfUserConfig(),

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -23,7 +23,7 @@ const (
 func TestAccResourceVcfUser(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		ProtoV6ProviderFactories: muxedFactories(),
 		CheckDestroy:      testCheckVcfUserDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_vcf_instance_test.go
+++ b/internal/provider/resource_vcf_instance_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestAccResourceVcfSddcBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxedFactories(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckVcfSddcConfigBasic(),


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Some acceptance tests fail if they try to use a resource that is already migrated to the framework.
Right now the only such resource is `vcf_network_pool`. To resolve this I've modified all tests to bootstrap
the provider in muxed mode so that all resources are available.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

For bug fixes or features:

- [X] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
