### PR TITLE
feat: integrate new task tracker

### DIFF
--- a/internal/certificates/certificate_operations.go
+++ b/internal/certificates/certificate_operations.go
@@ -83,11 +83,7 @@ func GenerateCertificateForResource(ctx context.Context, client *api_client.Sddc
 		api_client.LogError(vcfErr)
 		return errors.New(*vcfErr.Message)
 	}
-	err = client.WaitForTaskComplete(ctx, *task.Id, true)
-	if err != nil {
-		return err
-	}
-	return nil
+	return api_client.NewTaskTracker(ctx, client.ApiClient, *task.Id).WaitForTask()
 }
 
 func ReadCertificate(ctx context.Context, client *vcf.ClientWithResponses,

--- a/internal/credentials/credential_operations.go
+++ b/internal/credentials/credential_operations.go
@@ -206,11 +206,7 @@ func executeCredentialsUpdate(ctx context.Context, updateSpec *vcf.CredentialsUp
 		api_client.LogError(vcfErr)
 		return errors.New(*vcfErr.Message)
 	}
-	if err := sddcClient.WaitForTask(ctx, *task.Id); err != nil {
-		return err
-	}
-
-	return nil
+	return api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask()
 }
 
 func CreatePasswordChangeID(data *schema.ResourceData, operation string) (string, error) {

--- a/internal/provider/resource_ceip.go
+++ b/internal/provider/resource_ceip.go
@@ -105,7 +105,7 @@ func resourceCeipUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
 
-	if vcfClient.WaitForTask(ctx, *task.Id) != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -135,7 +135,7 @@ func resourceCeipDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
 
-	if vcfClient.WaitForTask(ctx, *task.Id) != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_certificate.go
+++ b/internal/provider/resource_certificate.go
@@ -83,7 +83,6 @@ func resourceResourceCertificateCreate(ctx context.Context, data *schema.Resourc
 		}},
 	}
 
-	var taskId string
 	res, err := apiClient.ReplaceCertificatesWithResponse(ctx, domainID, certificateOperationSpec)
 	if err != nil {
 		return diag.FromErr(err)
@@ -95,12 +94,10 @@ func resourceResourceCertificateCreate(ctx context.Context, data *schema.Resourc
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
 
-	taskId = *task.Id
-	err = vcfClient.WaitForTaskComplete(ctx, taskId, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
-	data.SetId("cert:" + domainID + ":" + resourceType + ":" + taskId)
+	data.SetId("cert:" + domainID + ":" + resourceType + ":" + *task.Id)
 
 	return resourceResourceCertificateRead(ctx, data, meta)
 }

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -335,12 +335,10 @@ func createCluster(ctx context.Context, domainId string, clusterSpec vcf.Cluster
 		api_client.LogError(vcfErr)
 		return "", diag.FromErr(errors.New(*vcfErr.Message))
 	}
-	taskId := *task.Id
-	err = vcfClient.WaitForTaskComplete(ctx, taskId, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return "", diag.FromErr(err)
 	}
-	clusterId, err := vcfClient.GetResourceIdAssociatedWithTask(ctx, taskId, "Cluster")
+	clusterId, err := vcfClient.GetResourceIdAssociatedWithTask(ctx, *task.Id, "Cluster")
 	if err != nil {
 		return "", diag.FromErr(err)
 	}
@@ -366,8 +364,7 @@ func updateCluster(ctx context.Context, clusterId string, clusterUpdateSpec vcf.
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
 
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, false)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 	return nil
@@ -400,8 +397,7 @@ func deleteCluster(ctx context.Context, clusterId string, vcfClient *api_client.
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
 
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 	return nil

--- a/internal/provider/resource_cluster_personality.go
+++ b/internal/provider/resource_cluster_personality.go
@@ -94,7 +94,7 @@ func resourceClusterPersonalityCreate(ctx context.Context, data *schema.Resource
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
 
-	if err := meta.(*api_client.SddcManagerClient).WaitForTaskComplete(ctx, *task.Id, false); err != nil {
+	if err = api_client.NewTaskTracker(ctx, client, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_csr.go
+++ b/internal/provider/resource_csr.go
@@ -150,8 +150,7 @@ func resourceCsrCreate(ctx context.Context, data *schema.ResourceData, meta inte
 		api_client.LogError(vcfErr)
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 	data.SetId(fmt.Sprintf("csr:%s:%s:%s:%s", domainId, resourceType, resourceFqdn, *task.Id))

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -143,12 +143,10 @@ func resourceDomainCreate(ctx context.Context, data *schema.ResourceData, meta i
 		api_client.LogError(vcfErr)
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
-	taskId := *task.Id
-	err = vcfClient.WaitForTaskComplete(ctx, taskId, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
-	domainId, err := vcfClient.GetResourceIdAssociatedWithTask(ctx, taskId, "Domain")
+	domainId, err := vcfClient.GetResourceIdAssociatedWithTask(ctx, *task.Id, "Domain")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -197,8 +195,7 @@ func resourceDomainUpdate(ctx context.Context, data *schema.ResourceData, meta i
 			return diag.FromErr(errors.New(*vcfErr.Message))
 		}
 
-		err = vcfClient.WaitForTaskComplete(ctx, *task.Id, false)
-		if err != nil {
+		if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -313,8 +310,7 @@ func resourceDomainDelete(ctx context.Context, data *schema.ResourceData, meta i
 		api_client.LogError(vcfErr)
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -182,8 +182,7 @@ func resourceNsxEdgeClusterCreate(ctx context.Context, data *schema.ResourceData
 	}
 
 	tflog.Info(ctx, "Edge cluster creation has started.")
-	err = meta.(*api_client.SddcManagerClient).WaitForTaskComplete(ctx, *task.Id, false)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, client, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -283,8 +282,7 @@ func resourceNsxEdgeClusterUpdate(ctx context.Context, data *schema.ResourceData
 			return diag.FromErr(errors.New(*vcfErr.Message))
 		}
 
-		err = meta.(*api_client.SddcManagerClient).WaitForTaskComplete(ctx, *task.Id, false)
-		if err != nil {
+		if err = api_client.NewTaskTracker(ctx, client, *task.Id).WaitForTask(); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/internal/provider/resource_external_certificate.go
+++ b/internal/provider/resource_external_certificate.go
@@ -125,8 +125,7 @@ func resourceResourceExternalCertificateCreate(ctx context.Context, data *schema
 		api_client.LogError(vcfErr)
 		return diag.FromErr(errors.New(*vcfErr.Message))
 	}
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, true)
-	if err != nil {
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 	data.SetId("ext_cert:" + domainID + ":" + resourceType + ":" + *task.Id)

--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -133,9 +133,7 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	tflog.Info(ctx, fmt.Sprintf("%s commissionSpec commission initiated. waiting for task id = %s",
 		commissionSpec.Fqdn, *task.Id))
 
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, false)
-	if err != nil {
-		tflog.Error(ctx, err.Error())
+	if err = api_client.NewTaskTrackerWithCustomPollingInterval(ctx, apiClient, *task.Id, time.Second*5).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 	hostId, err := vcfClient.GetResourceIdAssociatedWithTask(ctx, *task.Id, "Esxi")
@@ -219,9 +217,7 @@ func resourceHostDelete(ctx context.Context, d *schema.ResourceData, meta interf
 
 	log.Printf("%s %s: Decommission task initiated. Task id %s",
 		d.Get("fqdn").(string), d.Id(), *task.Id)
-	err = vcfClient.WaitForTaskComplete(ctx, *task.Id, false)
-	if err != nil {
-		tflog.Error(ctx, err.Error())
+	if err = api_client.NewTaskTracker(ctx, apiClient, *task.Id).WaitForTask(); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

An enchanced task tracker was added in [#227](https://github.com/vmware/terraform-provider-vcf/pull/227).
This PR plugs it into the codebase in the place of the existing task tracking functions.

To summarize the features of the new tracker:

It supports:
1. Sub-task message logging
2. Main task message logging
3. Custom polling interval configuration (see r/host for example). Some resources may benefit from frequent console updates.

It does not support
1. Task retrying. In my experience this has never worked and is not necessary.
Not because there is a bug in the current tracking implementation in the provider but because task failures
in VCF mean that something needs to change before an operation can be re-attempted

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #204

**Test and Documentation Coverage**

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

