### PR TITLE
chore(deps): bump SDK for vcf 5.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Learn more:
 
     | Platform                      | Support     |
     |-------------------------------|-------------|
+    | VMware Cloud Foundation 5.2.1 | `≥ v0.13.0` |
     | VMware Cloud Foundation 5.2.0 | `≥ v0.12.0` |
     | VMware Cloud Foundation 5.1+  | `≥ v0.9.0`  |
     | VMware Cloud Foundation 5.0   | `≥ v0.9.0`  |

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,8 @@ The following table lists the supported platforms for this provider.
 
 | Platform                       | Support     |
 |--------------------------------|-------------|
-| VMware Cloud Foundation 5.2.0+ | `≥ v0.12.0` |
+| VMware Cloud Foundation 5.2.1  | `≥ v0.13.0` |
+| VMware Cloud Foundation 5.2.0  | `≥ v0.12.0` |
 | VMware Cloud Foundation 5.1+   | `≥ v0.9.0`  |
 | VMware Cloud Foundation 5.0    | `≥ v0.9.0`  |
 | VMware Cloud Foundation 4.5    | `≤ v0.8.0`  |

--- a/docs/resources/edge_cluster.md
+++ b/docs/resources/edge_cluster.md
@@ -78,8 +78,8 @@ Required:
 
 Optional:
 
-- `compute_cluster_id` (String) The id of the compute cluster
-- `compute_cluster_name` (String) The name of the compute cluster
+- `compute_cluster_id` (String) The id of the compute cluster. You cannot specify a value for `compute_cluster_name` if you set this attribute.
+- `compute_cluster_name` (String) The name of the compute cluster. You cannot specify a value for `compute_cluster_id` if you set this attribute.
 - `first_nsx_vds_uplink` (String) The name of the first NSX-enabled VDS uplink
 - `management_network` (Block List, Max: 1) The management network which will be created for this node (see [below for nested schema](#nestedblock--edge_node--management_network))
 - `second_nsx_vds_uplink` (String) The name of the second NSX-enabled VDS uplink

--- a/docs/resources/edge_cluster.md
+++ b/docs/resources/edge_cluster.md
@@ -33,23 +33,23 @@ Review the documentation for VMware Cloud Foundation for more information about 
 ### Required
 
 - `admin_password` (String) Administrator password for the NSX manager
+- `asn` (Number) ASN for the cluster
 - `audit_password` (String) Audit user password for the NSX manager
 - `edge_node` (Block List, Min: 1) The nodes in the edge cluster (see [below for nested schema](#nestedblock--edge_node))
 - `form_factor` (String) One among: XLARGE, LARGE, MEDIUM, SMALL
+- `high_availability` (String) One among: ACTIVE_ACTIVE, ACTIVE_STANDBY
 - `mtu` (Number) Maximum transmission unit size for the cluster
 - `name` (String) The name of the edge cluster
 - `profile_type` (String) One among: DEFAULT, CUSTOM. If set to CUSTOM a 'profile' must be provided
 - `root_password` (String) Root user password for the NSX manager
+- `routing_type` (String) One among: EBGP, STATIC
+- `tier0_name` (String) Name for the Tier-0 gateway
 
 ### Optional
 
-- `asn` (Number) ASN for the cluster
-- `high_availability` (String) One among: ACTIVE_ACTIVE, ACTIVE_STANDBY
 - `internal_transit_subnets` (List of String) Subnet addresses in CIDR notation that are used to assign addresses to logical links connecting service routers and distributed routers
 - `profile` (Block List, Max: 1) The specification for the edge cluster profile (see [below for nested schema](#nestedblock--profile))
-- `routing_type` (String) One among: EBGP, STATIC
 - `skip_tep_routability_check` (Boolean) Set to true to bypass normal ICMP-based check of Edge TEP / host TEP routability (default is false, meaning do check)
-- `tier0_name` (String) Name for the Tier-0 gateway
 - `tier1_name` (String) Name for the Tier-1 gateway
 - `tier1_unhosted` (Boolean) Select whether Tier-1 being created per this spec is hosted on the new Edge cluster or not (default value is false, meaning hosted)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
@@ -78,8 +78,8 @@ Required:
 
 Optional:
 
-- `compute_cluster_id` (String) The id of the compute cluster. You cannot specify a value for `compute_cluster_name` if you set this attribute.
-- `compute_cluster_name` (String) The name of the compute cluster. You cannot specify a value for `compute_cluster_id` if you set this attribute.
+- `compute_cluster_id` (String) The id of the compute cluster
+- `compute_cluster_name` (String) The name of the compute cluster
 - `first_nsx_vds_uplink` (String) The name of the first NSX-enabled VDS uplink
 - `management_network` (Block List, Max: 1) The management network which will be created for this node (see [below for nested schema](#nestedblock--edge_node--management_network))
 - `second_nsx_vds_uplink` (String) The name of the second NSX-enabled VDS uplink
@@ -99,12 +99,9 @@ Required:
 
 Required:
 
+- `bgp_peer` (Block List, Min: 1) List of BGP Peer configurations (see [below for nested schema](#nestedblock--edge_node--uplink--bgp_peer))
 - `interface_ip` (String) The IP address (CIDR) for the distributed switch uplink
 - `vlan` (Number) The VLAN ID for the distributed switch uplink
-
-Optional:
-
-- `bgp_peer` (Block List) List of BGP Peer configurations (see [below for nested schema](#nestedblock--edge_node--uplink--bgp_peer))
 
 <a id="nestedblock--edge_node--uplink--bgp_peer"></a>
 ### Nested Schema for `edge_node.uplink.bgp_peer`

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.17.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/stretchr/testify v1.9.0
-	github.com/vmware/vcf-sdk-go v0.4.1
-	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	github.com/vmware/vcf-sdk-go v0.5.0
 )
 
 require (
@@ -81,6 +80,7 @@ require (
 	github.com/zclconf/go-cty v1.15.0 // indirect
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/vmware/terraform-provider-vcf
 
-go 1.22.6
-toolchain go1.22.9
+go 1.22.7
+
+toolchain go1.23.2
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/vcf-sdk-go v0.4.1 h1:Hd5flatP0xg0oEBcEabS6zYcMm6doVePJXzj4gfrfus=
-github.com/vmware/vcf-sdk-go v0.4.1/go.mod h1:MsPAnZU3YLGEIOc0RZcoHAk9sEIEQcuyJSWBPhRv8mQ=
+github.com/vmware/vcf-sdk-go v0.5.0 h1:GdbqDteAWLLI2S2u5HXXO/FWp7XCId/iefWIbDRxoDI=
+github.com/vmware/vcf-sdk-go v0.5.0/go.mod h1:MsPAnZU3YLGEIOc0RZcoHAk9sEIEQcuyJSWBPhRv8mQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/nsx_edge_cluster/edge_node_subresource.go
+++ b/internal/nsx_edge_cluster/edge_node_subresource.go
@@ -156,7 +156,7 @@ func UplinkNetworkSchema() *schema.Resource {
 			},
 			"bgp_peer": {
 				Type:        schema.TypeList,
-				Optional:    true,
+				Required:    true,
 				Description: "List of BGP Peer configurations",
 				Elem:        BgpPeerSchema(),
 			},

--- a/internal/provider/resource_ceip.go
+++ b/internal/provider/resource_ceip.go
@@ -93,7 +93,7 @@ func resourceCeipUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 	}
 
-	res, err := apiClient.SetCeipStatusWithResponse(ctx, vcf.CeipUpdateSpec{Status: enableApiParam})
+	res, err := apiClient.SetCeipStatusWithResponse(ctx, vcf.SetCeipStatusJSONRequestBody(enableApiParam))
 	if err != nil {
 		tflog.Error(ctx, err.Error())
 		return diag.FromErr(err)
@@ -119,11 +119,7 @@ func resourceCeipDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	vcfClient := meta.(*api_client.SddcManagerClient)
 	apiClient := vcfClient.ApiClient
 
-	updateSpec := vcf.CeipUpdateSpec{}
-	statusVal := DisableApiParam
-	updateSpec.Status = statusVal
-
-	ceipAccepted, err := apiClient.SetCeipStatusWithResponse(ctx, updateSpec)
+	ceipAccepted, err := apiClient.SetCeipStatusWithResponse(ctx, DisableApiParam)
 	if err != nil {
 		tflog.Error(ctx, err.Error())
 		return diag.FromErr(err)

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -66,7 +66,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"tier0_name": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				Description:  "Name for the Tier-0 gateway",
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -91,8 +91,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"routing_type": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"tier0_name"},
+				Required:     true,
 				Description:  "One among: EBGP, STATIC",
 				ValidateFunc: validation.StringInSlice([]string{"EBGP", "STATIC"}, false),
 			},
@@ -104,8 +103,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"high_availability": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"tier0_name"},
+				Required:     true,
 				Description:  "One among: ACTIVE_ACTIVE, ACTIVE_STANDBY",
 				ValidateFunc: validation.StringInSlice([]string{"ACTIVE_ACTIVE", "ACTIVE_STANDBY"}, false),
 			},
@@ -117,7 +115,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"asn": {
 				Type:         schema.TypeInt,
-				Optional:     true,
+				Required:     true,
 				Description:  "ASN for the cluster",
 				ValidateFunc: validation.IntBetween(1, int(math.Pow(2, 31)-1)),
 			},

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -21,40 +21,7 @@ const (
 	edgeNode3Name   = "nsxt-edge-node-5.vrack.vsphere.local"
 )
 
-// same as the "full" test but will most optional inputs omitted.
-func TestAccResourceEdgeCluster_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxedFactories(),
-		Steps: []resource.TestStep{
-			// Create
-			{
-				Config: getEdgeClusterConfigBasicInitial(),
-				Check: resource.ComposeTestCheckFunc(
-					getEdgeClusterChecks(2)...,
-				),
-			},
-			// Update
-			// Expand the cluster with an additional node
-			{
-				Config: getEdgeClusterConfigBasicExpansion(),
-				Check: resource.ComposeTestCheckFunc(
-					getEdgeClusterChecks(3)...,
-				),
-			},
-			// Update
-			// Shrink the cluster to its original set of nodes
-			{
-				Config: getEdgeClusterConfigBasicInitial(),
-				Check: resource.ComposeTestCheckFunc(
-					getEdgeClusterChecks(2)...,
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceEdgeCluster_full(t *testing.T) {
+func TestAccResourceEdgeCluster(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: muxedFactories(),
@@ -179,89 +146,6 @@ func getEdgeClusterConfigFullExpansion() string {
 		edgeNode3)
 }
 
-func getEdgeClusterConfigBasicInitial() string {
-	edgeNode1 := getEdgeNodeConfigBasic(
-		edgeNode1Name,
-		"10.0.0.52/24",
-		"192.168.52.12/24",
-		"192.168.52.13/24",
-		"192.168.18.2/24",
-		"192.168.19.2/24")
-	edgeNode2 := getEdgeNodeConfigBasic(
-		edgeNode2Name,
-		"10.0.0.53/24",
-		"192.168.52.14/24",
-		"192.168.52.15/24",
-		"192.168.18.3/24",
-		"192.168.19.3/24")
-
-	return fmt.Sprintf(`
-		resource "vcf_edge_cluster" "testCluster1" {
-			name      = %q
-			root_password = %q
-			admin_password = %q
-			audit_password = %q
-			form_factor = "MEDIUM"
-			profile_type = "DEFAULT"
-			mtu = 8940
-			%s
-			%s
-		}
-		`,
-		edgeClusterName,
-		os.Getenv(constants.VcfTestEdgeClusterRootPass),
-		os.Getenv(constants.VcfTestEdgeClusterAdminPass),
-		os.Getenv(constants.VcfTestEdgeClusterAuditPass),
-		edgeNode1,
-		edgeNode2)
-}
-
-func getEdgeClusterConfigBasicExpansion() string {
-	edgeNode1 := getEdgeNodeConfigBasic(
-		edgeNode1Name,
-		"10.0.0.52/24",
-		"192.168.52.12/24",
-		"192.168.52.13/24",
-		"192.168.18.2/24",
-		"192.168.19.2/24")
-	edgeNode2 := getEdgeNodeConfigBasic(
-		edgeNode2Name,
-		"10.0.0.53/24",
-		"192.168.52.14/24",
-		"192.168.52.15/24",
-		"192.168.18.3/24",
-		"192.168.19.3/24")
-	edgeNode3 := getEdgeNodeConfigBasic(
-		edgeNode3Name,
-		"10.0.0.54/24",
-		"192.168.52.16/24",
-		"192.168.52.17/24",
-		"192.168.18.6/24",
-		"192.168.19.6/24")
-
-	return fmt.Sprintf(`
-		resource "vcf_edge_cluster" "testCluster1" {
-			name      = %q
-			root_password = %q
-			admin_password = %q
-			audit_password = %q
-			form_factor = "MEDIUM"
-			mtu = 8940
-			asn = 65004
-			%s
-			%s
-			%s
-		}
-		`,
-		edgeClusterName,
-		os.Getenv(constants.VcfTestEdgeClusterRootPass),
-		os.Getenv(constants.VcfTestEdgeClusterAdminPass),
-		os.Getenv(constants.VcfTestEdgeClusterAuditPass),
-		edgeNode1,
-		edgeNode2,
-		edgeNode3)
-}
-
 func getEdgeNodeConfigFull(name, ip, tep1, tep2, uplink1, uplink2 string) string {
 	return fmt.Sprintf(`
 		edge_node {
@@ -301,45 +185,6 @@ func getEdgeNodeConfigFull(name, ip, tep1, tep2, uplink1, uplink2 string) string
 		`,
 		name,
 		os.Getenv(constants.VcfTestComputeClusterId),
-		os.Getenv(constants.VcfTestEdgeNodeRootPass),
-		os.Getenv(constants.VcfTestEdgeNodeAdminPass),
-		os.Getenv(constants.VcfTestEdgeNodeAuditPass),
-		ip,
-		tep1,
-		tep2,
-		uplink1,
-		uplink2)
-}
-
-func getEdgeNodeConfigBasic(name, ip, tep1, tep2, uplink1, uplink2 string) string {
-	return fmt.Sprintf(`
-		edge_node {
-			name = %q
-			compute_cluster_name = %q
-			root_password = %q
-			admin_password = %q
-			audit_password = %q
-			management_ip = %q
-			management_gateway = "10.0.0.250"
-			tep_gateway = "192.168.52.1"
-			tep1_ip = %q
-			tep2_ip = %q
-			tep_vlan = 1252
-			inter_rack_cluster = false
-
-			uplink {
-				vlan = 2083
-				interface_ip = %q
-			}
-
-			uplink {
-				vlan = 2084
-				interface_ip = %q
-			}
-		}
-		`,
-		name,
-		os.Getenv(constants.VcfTestComputeClusterName),
 		os.Getenv(constants.VcfTestEdgeNodeRootPass),
 		os.Getenv(constants.VcfTestEdgeNodeAdminPass),
 		os.Getenv(constants.VcfTestEdgeNodeAuditPass),


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This PR consumes the latest SDK release (v0.5.0) which contains API support for VCF 5.2.1
an does not include any integration of new functionality that may be exposed by the new API.

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

Ran the tests for some of the "heavier" resources - domain, cluster, edge cluster

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [X] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

Some of the optional properties for edge clusters are now required. Due to this I also removed the "basic" edge cluster test since it's no longer applicable. The "full" test scenario is still valid