### PR TITLE
fix: add 8.0.3 to dvSwitchVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v0.13.1
+
+> Release Date: Not Released
+
+BUG FIXES:
+
+- Adds 8.0.3 to the allowed `dvSwitchVersion` to support vSphere 8.0 U3. [#274](https://github.com/vmware/terraform-provider-vcf/pull/274)
+
 ## [v0.13.0](https://github.com/vmware/terraform-provider-vcf/releases/tag/v0.13.0)
 
 > Release Date: 2024-11-26

--- a/internal/provider/resource_vcf_instance.go
+++ b/internal/provider/resource_vcf_instance.go
@@ -22,7 +22,7 @@ import (
 	validationutils "github.com/vmware/terraform-provider-vcf/internal/validation"
 )
 
-var dvSwitchVersions = []string{"7.0.0", "7.0.2", "7.0.3", "8.0.0"}
+var dvSwitchVersions = []string{"7.0.0", "7.0.2", "7.0.3", "8.0.0", "8.0.3"}
 
 func ResourceVcfInstance() *schema.Resource {
 	return &schema.Resource{
@@ -85,7 +85,7 @@ func resourceVcfInstanceSchema() map[string]*schema.Schema {
 		"dvs":     sddc.GetDvsSchema(),
 		"dv_switch_version": {
 			Type:         schema.TypeString,
-			Description:  "The version of the distributed virtual switches to be used. One among: 7.0.0, 7.0.2, 7.0.3, 8.0.0",
+			Description:  "The version of the distributed virtual switches to be used. One among: 7.0.0, 7.0.2, 7.0.3, 8.0.0, 8.0.3",
 			Required:     true,
 			ValidateFunc: validation.StringInSlice(dvSwitchVersions, false),
 		},


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

Adds `8.0.3` to the allowed `dvSwitchVersion` to support vSphere 8.0 U3.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
