### PR TITLE
Relax Edge Cluster setting restrictions for Tier0/1 routers and ASN

### DIFF
--- a/docs/resources/edge_cluster.md
+++ b/docs/resources/edge_cluster.md
@@ -42,12 +42,10 @@ Review the documentation for VMware Cloud Foundation for more information about 
 - `profile_type` (String) One among: DEFAULT, CUSTOM. If set to CUSTOM a 'profile' must be provided
 - `root_password` (String) Root user password for the NSX manager
 - `routing_type` (String) One among: EBGP, STATIC
-- `tier0_name` (String) Name for the Tier-0 gateway
 
 ### Optional
 
 - `internal_transit_subnets` (List of String) Subnet addresses in CIDR notation that are used to assign addresses to logical links connecting service routers and distributed routers
-
 - `profile` (Block List, Max: 1) The specification for the edge cluster profile (see [below for nested schema](#nestedblock--profile))
 - `skip_tep_routability_check` (Boolean) Set to true to bypass normal ICMP-based check of Edge TEP / host TEP routability (default is false, meaning do check)
 - `tier1_name` (String) Name for the Tier-1 gateway
@@ -60,7 +58,6 @@ Review the documentation for VMware Cloud Foundation for more information about 
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--edge_node"></a>
-
 ### Nested Schema for `edge_node`
 
 Required:
@@ -79,16 +76,14 @@ Required:
 
 Optional:
 
-- `compute_cluster_id` (String) The id of the compute cluster. You cannot specify a value for `compute_cluster_name` if you set this attribute.
-- `compute_cluster_name` (String) The name of the compute cluster. You cannot specify a value for `compute_cluster_id` if you set this attribute.
-
+- `compute_cluster_id` (String) The id of the compute cluster
+- `compute_cluster_name` (String) The name of the compute cluster
 - `first_nsx_vds_uplink` (String) The name of the first NSX-enabled VDS uplink
 - `management_network` (Block List, Max: 1) The management network which will be created for this node (see [below for nested schema](#nestedblock--edge_node--management_network))
 - `second_nsx_vds_uplink` (String) The name of the second NSX-enabled VDS uplink
 - `uplink` (Block List) Specifications of Tier-0 uplinks for the edge node (see [below for nested schema](#nestedblock--edge_node--uplink))
 
 <a id="nestedblock--edge_node--management_network"></a>
-
 ### Nested Schema for `edge_node.management_network`
 
 Required:
@@ -96,8 +91,8 @@ Required:
 - `portgroup_name` (String) The name of the portgroup
 - `vlan_id` (Number) The VLAN ID for the portgroup
 
-<a id="nestedblock--edge_node--uplink"></a>
 
+<a id="nestedblock--edge_node--uplink"></a>
 ### Nested Schema for `edge_node.uplink`
 
 Required:
@@ -107,7 +102,6 @@ Required:
 - `vlan` (Number) The VLAN ID for the distributed switch uplink
 
 <a id="nestedblock--edge_node--uplink--bgp_peer"></a>
-
 ### Nested Schema for `edge_node.uplink.bgp_peer`
 
 Required:
@@ -116,8 +110,10 @@ Required:
 - `ip` (String) IP address
 - `password` (String) Password
 
-<a id="nestedblock--profile"></a>
 
+
+
+<a id="nestedblock--profile"></a>
 ### Nested Schema for `profile`
 
 Required:
@@ -128,8 +124,8 @@ Required:
 - `name` (String) The name of the profile
 - `standby_relocation_threshold` (Number) Standby relocation threshold
 
-<a id="nestedblock--timeouts"></a>
 
+<a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -65,7 +65,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"tier0_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  "Name for the Tier-0 gateway",
 				ValidateFunc: validation.NoZeroValues,
 			},

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -75,8 +75,6 @@ func getEdgeClusterConfigFullInitial() string {
 			root_password = %q
 			admin_password = %q
 			audit_password = %q
-			tier0_name = "T0_testCluster1"
-			tier1_name = "T1_testCluster1"
 			form_factor = "MEDIUM"
 			profile_type = "DEFAULT"
 			routing_type = "EBGP"

--- a/internal/validation/validation_utils.go
+++ b/internal/validation/validation_utils.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -322,11 +321,8 @@ func ValidASN(v interface{}, k string) (ws []string, errors []error) {
 		return
 	}
 
-	isLegacyAsn := slices.Contains([]int64{7224, 9059, 10124, 17493}, asn)
-	isPublicAsn := (asn >= 1 && asn <= 64495) || (asn >= 131072 && asn <= 4199999999)
-
-	if !isLegacyAsn && !isPublicAsn && ((asn < 64512) || (asn > 65534 && asn < 4200000000) || (asn > 4294967294)) {
-		errors = append(errors, fmt.Errorf("%q (%q) must be a legacy ASN, a non-private ASN, or in the range 64512 to 65534 or 4200000000 to 4294967294", k, v))
+	if asn < 1 || asn > 4294967294 {
+		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 1 to 4294967294", k, v))
 	}
 
 	return


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Making Tier 0 router name optional again and relaxing ASN restrictions while preserving the range limit.

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

https://github.com/vmware/terraform-provider-vcf/issues/293

https://github.com/vmware/terraform-provider-vcf/issues/294

**Test and Documentation Coverage**

For bug fixes or features:

- [X] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
