### PR TITLE
feat: set asn and routing type as optional for edge clusters

### DIFF
--- a/docs/resources/edge_cluster.md
+++ b/docs/resources/edge_cluster.md
@@ -32,7 +32,6 @@ Review the documentation for VMware Cloud Foundation for more information about 
 ### Required
 
 - `admin_password` (String) Administrator password for the NSX manager
-- `asn` (String) ASN for the cluster
 - `audit_password` (String) Audit user password for the NSX manager
 - `edge_node` (Block List, Min: 1) The nodes in the edge cluster (see [below for nested schema](#nestedblock--edge_node))
 - `form_factor` (String) One among: XLARGE, LARGE, MEDIUM, SMALL
@@ -41,13 +40,15 @@ Review the documentation for VMware Cloud Foundation for more information about 
 - `name` (String) The name of the edge cluster
 - `profile_type` (String) One among: DEFAULT, CUSTOM. If set to CUSTOM a 'profile' must be provided
 - `root_password` (String) Root user password for the NSX manager
-- `routing_type` (String) One among: EBGP, STATIC
 
 ### Optional
 
+- `asn` (String) ASN for the cluster
 - `internal_transit_subnets` (List of String) Subnet addresses in CIDR notation that are used to assign addresses to logical links connecting service routers and distributed routers
 - `profile` (Block List, Max: 1) The specification for the edge cluster profile (see [below for nested schema](#nestedblock--profile))
+- `routing_type` (String) One among: EBGP, STATIC
 - `skip_tep_routability_check` (Boolean) Set to true to bypass normal ICMP-based check of Edge TEP / host TEP routability (default is false, meaning do check)
+- `tier0_name` (String) Name for the Tier-0 gateway
 - `tier1_name` (String) Name for the Tier-1 gateway
 - `tier1_unhosted` (Boolean) Select whether Tier-1 being created per this spec is hosted on the new Edge cluster or not (default value is false, meaning hosted)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/internal/provider/resource_edge_cluster.go
+++ b/internal/provider/resource_edge_cluster.go
@@ -90,7 +90,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"routing_type": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  "One among: EBGP, STATIC",
 				ValidateFunc: validation.StringInSlice([]string{"EBGP", "STATIC"}, false),
 			},
@@ -114,7 +114,7 @@ func ResourceEdgeCluster() *schema.Resource {
 			},
 			"asn": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  "ASN for the cluster",
 				ValidateFunc: validationUtils.ValidASN,
 			},

--- a/internal/provider/resource_edge_cluster_test.go
+++ b/internal/provider/resource_edge_cluster_test.go
@@ -77,10 +77,8 @@ func getEdgeClusterConfigFullInitial() string {
 			audit_password = %q
 			form_factor = "MEDIUM"
 			profile_type = "DEFAULT"
-			routing_type = "EBGP"
 			high_availability = "ACTIVE_ACTIVE"
 			mtu = 8940
-			asn = "65004"
 			%s
 			%s
 		}
@@ -122,14 +120,10 @@ func getEdgeClusterConfigFullExpansion() string {
 			root_password = %q
 			admin_password = %q
 			audit_password = %q
-			tier0_name = "T0_testCluster1"
-			tier1_name = "T1_testCluster1"
 			form_factor = "MEDIUM"
 			profile_type = "DEFAULT"
-			routing_type = "EBGP"
 			high_availability = "ACTIVE_ACTIVE"
 			mtu = 8940
-			asn = "65004"
 			%s
 			%s
 			%s


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Marking `asn` and `routing_type` as optional inputs for edge clusters

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

For bug fixes or features:

- [ ] Tests have been completed.
- [X] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
