### PR TITLE
refactor: remove `once_only` in `r/credential`

### DIFF
--- a/docs/resources/credentials_rotate.md
+++ b/docs/resources/credentials_rotate.md
@@ -3,7 +3,7 @@
 page_title: "vcf_credentials_rotate Resource - terraform-provider-vcf"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # vcf_credentials_rotate (Resource)
@@ -20,10 +20,6 @@ description: |-
 - `credentials` (Block List, Min: 1) The credentials that should be rotated (see [below for nested schema](#nestedblock--credentials))
 - `resource_name` (String) The name of the resource which credentials will be rotated
 - `resource_type` (String) The type of the resource which credentials will be rotated
-
-### Optional
-
-- `once_only` (Boolean) If set to true operation is executed only once otherwise rotation is done each time.
 
 ### Read-Only
 

--- a/docs/resources/credentials_update.md
+++ b/docs/resources/credentials_update.md
@@ -3,7 +3,7 @@
 page_title: "vcf_credentials_update Resource - terraform-provider-vcf"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # vcf_credentials_update (Resource)
@@ -20,10 +20,6 @@ description: |-
 - `credentials` (Block List, Min: 1) The credentials that should be updated (see [below for nested schema](#nestedblock--credentials))
 - `resource_name` (String) The name of the resource which credentials will be updated
 - `resource_type` (String) The type of the resource which credentials will be updated
-
-### Optional
-
-- `once_only` (Boolean) If set to true operation is executed only once otherwise rotation is done each time.
 
 ### Read-Only
 

--- a/internal/provider/resource_credentials_password_rotate.go
+++ b/internal/provider/resource_credentials_password_rotate.go
@@ -65,13 +65,6 @@ func ResourceCredentialsRotate() *schema.Resource {
 					},
 				},
 			},
-			"once_only": {
-				Type:        schema.TypeBool,
-				Default:     true,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "If set to true operation is executed only once otherwise rotation is done each time.",
-			},
 			"last_rotate_time": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,7 +104,7 @@ func resourceCredentialsPasswordRotationRead(ctx context.Context, data *schema.R
 }
 
 func resourceCredentialsPasswordRotationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.Get("last_rotate_time").(string) != "" && d.Get("once_only").(bool) {
+	if d.Get("last_rotate_time").(string) != "" {
 		log.Print("[DEBUG] Skipping password rotation")
 		return nil
 	}

--- a/internal/provider/resource_credentials_password_update.go
+++ b/internal/provider/resource_credentials_password_update.go
@@ -64,13 +64,6 @@ func ResourceCredentialsUpdate() *schema.Resource {
 					},
 				},
 			},
-			"once_only": {
-				Type:        schema.TypeBool,
-				Default:     true,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "If set to true operation is executed only once otherwise rotation is done each time.",
-			},
 			"last_update_time": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,7 +104,7 @@ func resourceCredentialsPasswordUpdateRead(ctx context.Context, data *schema.Res
 }
 
 func resourceCredentialsPasswordUpdateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.Get("last_update_time").(string) != "" && d.Get("once_only").(bool) {
+	if d.Get("last_update_time").(string) != "" {
 		log.Print("[DEBUG] Skipping password rotation")
 		return nil
 	}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Removes support for `once_only` in `r/credential`.

Closes #226

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
