### PR TITLE
fix: add `cluster_id` to `r/instance`

### DIFF
--- a/internal/provider/resource_vcf_instance.go
+++ b/internal/provider/resource_vcf_instance.go
@@ -130,13 +130,13 @@ func resourceVcfInstanceSchema() map[string]*schema.Schema {
 	}
 }
 
-func buildSddcSpec(data *schema.ResourceData) *vcf.SddcSpec {
+func buildSddcSpec(data *schema.ResourceData, apiClient *vcf.ClientWithResponses) *vcf.SddcSpec {
 	sddcSpec := &vcf.SddcSpec{}
 	if rawCeipEnabled, ok := data.GetOk("ceip_enabled"); ok {
 		sddcSpec.CeipEnabled = utils.ToBoolPointer(rawCeipEnabled)
 	}
 	if clusterSpec, ok := data.GetOk("cluster"); ok {
-		sddcSpec.ClusterSpec = sddc.GetSddcClusterSpecFromSchema(clusterSpec.([]interface{}))
+		sddcSpec.ClusterSpec = sddc.GetSddcClusterSpecFromSchema(clusterSpec.([]interface{}), apiClient)
 	}
 	if dnsSpec, ok := data.GetOk("dns"); ok {
 		spec := sddc.GetDnsSpecFromSchema(dnsSpec.([]interface{}))
@@ -205,7 +205,7 @@ func buildSddcSpec(data *schema.ResourceData) *vcf.SddcSpec {
 func resourceVcfInstanceCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*api_client.CloudBuilderClient)
 
-	sddcSpec := buildSddcSpec(data)
+	sddcSpec := buildSddcSpec(data, client.ApiClient)
 
 	bringUpInfo, err := getLastBringUp(ctx, client)
 	if err != nil {


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

🚧 **DRAFT** 🚧 

Adds support to return the computed `cluster_id` as part of the `r/instance`.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Closes #252

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
