### PR TITLE
feat: Add user-agent header

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - -s -w -X 'github.com/vmware/terraform-provider-vcf/internal/version.ProviderVersion={{ .Version }}'
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 archives:

--- a/internal/api_client/cloud_builder_client.go
+++ b/internal/api_client/cloud_builder_client.go
@@ -19,15 +19,17 @@ type CloudBuilderClient struct {
 	username           string
 	password           string
 	cloudBuilderUrl    string
+	providerVersion    string
 	ApiClient          *vcf.ClientWithResponses
 	allowUnverifiedTls bool
 }
 
-func NewCloudBuilderClient(username, password, url string, allowUnverifiedTls bool) *CloudBuilderClient {
+func NewCloudBuilderClient(username, password, url, providerVersion string, allowUnverifiedTls bool) *CloudBuilderClient {
 	result := &CloudBuilderClient{
 		username:           username,
 		password:           password,
 		cloudBuilderUrl:    url,
+		providerVersion:    providerVersion,
 		allowUnverifiedTls: allowUnverifiedTls,
 	}
 	result.init()
@@ -49,6 +51,7 @@ func (cloudBuilderClient *CloudBuilderClient) init() {
 func (cloudBuilderClient *CloudBuilderClient) authEditor(ctx context.Context, req *http.Request) error {
 	req.SetBasicAuth(cloudBuilderClient.username, cloudBuilderClient.password)
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("terraform-provider-vcf/%s", cloudBuilderClient.providerVersion))
 
 	return nil
 }

--- a/internal/api_client/sddc_manager_client.go
+++ b/internal/api_client/sddc_manager_client.go
@@ -23,6 +23,7 @@ type SddcManagerClient struct {
 	username           string
 	password           string
 	sddcManagerUrl     string
+	providerVersion    string
 	accessToken        *string
 	ApiClient          *vcf.ClientWithResponses
 	allowUnverifiedTls bool
@@ -31,11 +32,12 @@ type SddcManagerClient struct {
 }
 
 // NewSddcManagerClient constructs new Client instance with vcf credentials.
-func NewSddcManagerClient(username, password, url string, allowUnverifiedTls bool) *SddcManagerClient {
+func NewSddcManagerClient(username, password, url, providerVersion string, allowUnverifiedTls bool) *SddcManagerClient {
 	return &SddcManagerClient{
 		username:           username,
 		password:           password,
 		sddcManagerUrl:     url,
+		providerVersion:    providerVersion,
 		allowUnverifiedTls: allowUnverifiedTls,
 		lastRefreshTime:    time.Now(),
 		isRefreshing:       false,
@@ -54,10 +56,11 @@ func (sddcManagerClient *SddcManagerClient) authEditor(ctx context.Context, req 
 	}
 
 	if sddcManagerClient.accessToken != nil {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *sddcManagerClient.accessToken))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *sddcManagerClient.accessToken))
 	}
 
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("terraform-provider-vcf/%s", sddcManagerClient.providerVersion))
+	req.Header.Set("Content-Type", "application/json")
 
 	return nil
 }

--- a/internal/provider/framework_provider.go
+++ b/internal/provider/framework_provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vmware/terraform-provider-vcf/internal/version"
 
 	"github.com/vmware/terraform-provider-vcf/internal/api_client"
 	"github.com/vmware/terraform-provider-vcf/internal/constants"
@@ -159,6 +160,7 @@ func (frameworkProvider *FrameworkProvider) Configure(ctx context.Context, req p
 			sddcManagerUsername,
 			getAttributeValue(data.SddcManagerPassword.ValueString(), constants.VcfTestPassword).(string),
 			getAttributeValue(data.SddcManagerHost.ValueString(), constants.VcfTestUrl).(string),
+			version.ProviderVersion,
 			getAttributeValue(data.AllowUnverifiedTls.ValueBool(), constants.VcfTestAllowUnverifiedTls).(bool),
 		)
 
@@ -174,6 +176,7 @@ func (frameworkProvider *FrameworkProvider) Configure(ctx context.Context, req p
 			getAttributeValue(data.CloudBuilderUsername.ValueString(), constants.CloudBuilderTestUsername).(string),
 			getAttributeValue(data.CloudBuilderPassword.ValueString(), constants.CloudBuilderTestPassword).(string),
 			getAttributeValue(data.CloudBuilderHost.ValueString(), constants.CloudBuilderTestUrl).(string),
+			version.ProviderVersion,
 			getAttributeValue(data.AllowUnverifiedTls.ValueBool(), constants.VcfTestAllowUnverifiedTls).(bool),
 		)
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/terraform-provider-vcf/internal/version"
 
 	"github.com/vmware/terraform-provider-vcf/internal/api_client"
 	"github.com/vmware/terraform-provider-vcf/internal/constants"
@@ -121,7 +122,7 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 			return nil, diag.Errorf("SDDC Manager username, password, and host must be provided.")
 		}
 		var sddcManagerClient = api_client.NewSddcManagerClient(sddcManagerUsername.(string), password.(string),
-			hostName.(string), allowUnverifiedTLS.(bool))
+			hostName.(string), version.ProviderVersion, allowUnverifiedTLS.(bool))
 		err := sddcManagerClient.Connect()
 		if err != nil {
 			return nil, diag.FromErr(err)
@@ -136,7 +137,7 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 			return nil, diag.Errorf("Cloud Builder username, password, and host must be provided.")
 		}
 		var cloudBuilderClient = api_client.NewCloudBuilderClient(cbUsername.(string), password.(string),
-			hostName.(string), allowUnverifiedTLS.(bool))
+			hostName.(string), version.ProviderVersion, allowUnverifiedTLS.(bool))
 		return cloudBuilderClient, nil
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// ProviderVersion is set during the release process to the release version of the binary
+var ProviderVersion = "dev"


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Add a `User-Agent` header to all API requests.
The header is in the following format `terraform-provider-vcf/<binary_version>`, for example - `terraform-provider-vcf/0.15.1`

The version is set during the release process, the default value during development is "dev"

**Type of Pull Request**

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

Built locally using goreleaser 2.8.2
Created a mock server that accepts all requests on a custom port
Modified the provider to use plain http and connected to the mock server
Verified that all API requests are issued with the new header and that the version is set properly by goreleaser

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

N/A
