### PR TITLE
fix: host subresource ip allocation optional subnet

### DIFF
--- a/internal/sddc/sddc_host_subresource.go
+++ b/internal/sddc/sddc_host_subresource.go
@@ -123,13 +123,17 @@ func getIPAllocationBindingFromSchema(rawData []interface{}) *vcf.IpAllocation {
 	cidr := data["cidr"].(string)
 	gateway := data["gateway"].(string)
 	ipAddress := data["ip_address"].(string)
-	subnet := data["subnet"].(string)
+
+	var subnet *string
+	if data["subnet"].(string) != "" {
+		subnet = utils.ToStringPointer(data["subnet"])
+	}
 
 	ipAllocationBinding := &vcf.IpAllocation{
 		Cidr:      &cidr,
 		Gateway:   &gateway,
 		IpAddress: ipAddress,
-		Subnet:    &subnet,
+		Subnet:    subnet,
 	}
 	return ipAllocationBinding
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Do not transmit empty host subnet values when doing bringup.
The subnet setting is optional for hosts but the Cloud Builder API doesn't like receiving empty strings.

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Closes #312

**Test and Documentation Coverage**

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

