### PR TITLE
fix: read tier1 router name correctly from schema

### DIFF
--- a/internal/nsx_edge_cluster/edge_cluster_operations.go
+++ b/internal/nsx_edge_cluster/edge_cluster_operations.go
@@ -41,7 +41,7 @@ func GetNsxEdgeClusterCreationSpec(data *schema.ResourceData, client *vcf.Client
 
 	var tier1Name *string
 	if data.Get("tier1_name").(string) != "" {
-		tier1Name = resource_utils.ToStringPointer(data.Get("tier1Name"))
+		tier1Name = resource_utils.ToStringPointer(data.Get("tier1_name"))
 	}
 
 	transitSubnets := resource_utils.ToStringSlice(data.Get("transit_subnets").([]interface{}))


### PR DESCRIPTION
**Summary of Pull Request**

Simple typo fix `tier1Name` -> `tier1_name`

**Type of Pull Request**

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: https://github.com/vmware/terraform-provider-vcf/issues/324

**Test and Documentation Coverage**

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
