### PR TITLE
fix: `vcf_instance` doesn't handle NSX enabled DVS with VCF 9.0

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -8,12 +8,6 @@ description: |-
 
 # vcf_instance (Resource)
 
-Create an SDDC workflow (bringup) executes automatically the following:
-
-* Configures networking on each host.
-* Configures vSAN storage on the hosts.
-* Deploys and configures the management stack - vCenter and NSX
-* Deploys and configures SDDC Manager which provides the ability to perform Day 2 operations
 
 
 
@@ -46,6 +40,7 @@ Create an SDDC workflow (bringup) executes automatically the following:
 - `sddc_manager` (Block List, Max: 1) (see [below for nested schema](#nestedblock--sddc_manager))
 - `security` (Block List, Max: 1) (see [below for nested schema](#nestedblock--security))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `version` (String) VCF version
 - `vsan` (Block List, Max: 1) (see [below for nested schema](#nestedblock--vsan))
 
 ### Read-Only
@@ -118,6 +113,8 @@ Optional:
 
 - `mtu` (Number) DVS MTU (default value is 9000). In between 1500 and 9000
 - `nioc` (Block List) List of NIOC specs for networks (see [below for nested schema](#nestedblock--dvs--nioc))
+- `nsx_teaming` (Block List) NSX teaming policies for uplink profiles (see [below for nested schema](#nestedblock--dvs--nsx_teaming))
+- `nsxt_switch_config` (Block List, Max: 1) NSX-T switch configuration (see [below for nested schema](#nestedblock--dvs--nsxt_switch_config))
 
 <a id="nestedblock--dvs--vmnic_mapping"></a>
 ### Nested Schema for `dvs.vmnic_mapping`
@@ -135,6 +132,44 @@ Required:
 
 - `traffic_type` (String) Traffic Type One among:VSAN, VMOTION, VIRTUALMACHINE, MANAGEMENT, NFS, VDP, HBR, FAULTTOLERANCE, ISCSI
 - `value` (String) NIOC Value. Example: LOW, NORMAL, HIGH
+
+
+<a id="nestedblock--dvs--nsx_teaming"></a>
+### Nested Schema for `dvs.nsx_teaming`
+
+Required:
+
+- `active_uplinks` (List of String) List of active uplinks
+- `policy` (String) Teaming policy (e.g., FAILOVER_ORDER, LOADBALANCE_SRCID)
+
+Optional:
+
+- `standby_uplinks` (List of String) List of standby uplinks
+
+
+<a id="nestedblock--dvs--nsxt_switch_config"></a>
+### Nested Schema for `dvs.nsxt_switch_config`
+
+Required:
+
+- `transport_zones` (Block List, Min: 1) Transport zones for NSX switch (see [below for nested schema](#nestedblock--dvs--nsxt_switch_config--transport_zones))
+
+Optional:
+
+- `host_switch_operational_mode` (String) Host switch operational mode (e.g., STANDARD, ENS)
+- `ip_assignment_type` (String) IP assignment type for host switch
+
+<a id="nestedblock--dvs--nsxt_switch_config--transport_zones"></a>
+### Nested Schema for `dvs.nsxt_switch_config.transport_zones`
+
+Required:
+
+- `transport_type` (String) Transport type (e.g., OVERLAY, VLAN)
+
+Optional:
+
+- `name` (String) Transport zone name
+
 
 
 
@@ -387,4 +422,5 @@ Required:
 Optional:
 
 - `esa_enabled` (Boolean) Enable vSAN ESA
+- `failures_to_tolerate` (Number) Host failures to tolerate
 - `vsan_dedup` (Boolean) VSAN feature Deduplication and Compression flag, one flag for both features

--- a/internal/provider/resource_vcf_instance.go
+++ b/internal/provider/resource_vcf_instance.go
@@ -96,6 +96,11 @@ func resourceVcfInstanceSchema() map[string]*schema.Schema {
 		"operations":                  sddc.GetVcfOperationsSchema(),
 		"operations_collector":        sddc.GetVcfOperationsCollectorSchema(),
 		"operations_fleet_management": sddc.GetVcfOperationsFleetManagementSchema(),
+		"version": {
+			Type:        schema.TypeString,
+			Description: "VCF version",
+			Optional:    true,
+		},
 	}
 }
 
@@ -171,6 +176,9 @@ func buildSddcSpec(data *schema.ResourceData) *installer.SddcSpec {
 		if spec := sddc.GetVcfOperationsFleetManagementSpecFromSchema(operationsFleetManagementSpec.([]interface{})); spec != nil {
 			sddcSpec.VcfOperationsFleetManagementSpec = spec
 		}
+	}
+	if version, ok := data.GetOk("version"); ok {
+		sddcSpec.Version = utils.ToStringPointer(version)
 	}
 	return sddcSpec
 }

--- a/internal/sddc/dvs_subresource.go
+++ b/internal/sddc/dvs_subresource.go
@@ -59,6 +59,71 @@ func GetDvsSchema() *schema.Schema {
 						},
 					},
 				},
+				"nsx_teaming": {
+					Type:        schema.TypeList,
+					Description: "NSX teaming policies for uplink profiles",
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"policy": {
+								Type:        schema.TypeString,
+								Description: "Teaming policy (e.g., FAILOVER_ORDER, LOADBALANCE_SRCID)",
+								Required:    true,
+							},
+							"active_uplinks": {
+								Type:        schema.TypeList,
+								Description: "List of active uplinks",
+								Required:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+							"standby_uplinks": {
+								Type:        schema.TypeList,
+								Description: "List of standby uplinks",
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+				"nsxt_switch_config": {
+					Type:        schema.TypeList,
+					Description: "NSX-T switch configuration",
+					Optional:    true,
+					MaxItems:    1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"host_switch_operational_mode": {
+								Type:        schema.TypeString,
+								Description: "Host switch operational mode (e.g., STANDARD, ENS)",
+								Optional:    true,
+							},
+							"ip_assignment_type": {
+								Type:        schema.TypeString,
+								Description: "IP assignment type for host switch",
+								Optional:    true,
+							},
+							"transport_zones": {
+								Type:        schema.TypeList,
+								Description: "Transport zones for NSX switch",
+								Required:    true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"name": {
+											Type:        schema.TypeString,
+											Description: "Transport zone name",
+											Optional:    true,
+										},
+										"transport_type": {
+											Type:        schema.TypeString,
+											Description: "Transport type (e.g., OVERLAY, VLAN)",
+											Required:    true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -111,6 +176,14 @@ func GetDvsSpecsFromSchema(rawData []interface{}) *[]installer.DvsSpec {
 			}
 		}
 
+		if nsxTeamings, ok := dvsSpecRaw["nsx_teaming"].([]interface{}); ok {
+			dvsSpec.NsxTeamings = convertNsxTeamings(nsxTeamings)
+		}
+
+		if nsxtSwitchConfig, ok := dvsSpecRaw["nsxt_switch_config"].([]interface{}); ok && len(nsxtSwitchConfig) > 0 {
+			dvsSpec.NsxtSwitchConfig = convertNsxtSwitchConfig(nsxtSwitchConfig[0].(map[string]interface{}))
+		}
+
 		dvsSpecs = append(dvsSpecs, dvsSpec)
 	}
 	return &dvsSpecs
@@ -121,4 +194,63 @@ func getVmnicToUplink(rawData map[string]interface{}) installer.VmnicToUplink {
 		Uplink: rawData["uplink"].(string),
 		Id:     rawData["vmnic"].(string),
 	}
+}
+
+func convertNsxTeamings(rawData []interface{}) *[]installer.TeamingSpec {
+	if len(rawData) == 0 {
+		return nil
+	}
+
+	teamings := make([]installer.TeamingSpec, len(rawData))
+	for i, teamingRaw := range rawData {
+		teaming := teamingRaw.(map[string]interface{})
+		teamingSpec := installer.TeamingSpec{
+			Policy:        teaming["policy"].(string),
+			ActiveUplinks: utils.ToStringSlice(teaming["active_uplinks"].([]interface{})),
+		}
+
+		if standbyUplinks, ok := teaming["standby_uplinks"].([]interface{}); ok {
+			standbySlice := utils.ToStringSlice(standbyUplinks)
+			teamingSpec.StandByUplinks = &standbySlice
+		}
+
+		teamings[i] = teamingSpec
+	}
+	return &teamings
+}
+
+func convertNsxtSwitchConfig(rawData map[string]interface{}) *installer.NsxtSwitchConfig {
+	config := &installer.NsxtSwitchConfig{}
+	hasConfig := false
+
+	if mode, ok := rawData["host_switch_operational_mode"].(string); ok && mode != "" {
+		config.HostSwitchOperationalMode = utils.ToStringPointer(mode)
+		hasConfig = true
+	}
+
+	if ipType, ok := rawData["ip_assignment_type"].(string); ok && ipType != "" {
+		config.IpAssignmentType = utils.ToStringPointer(ipType)
+		hasConfig = true
+	}
+
+	if tzRaw, ok := rawData["transport_zones"].([]interface{}); ok {
+		transportZones := make([]installer.TransportZone, len(tzRaw))
+		for i, tzData := range tzRaw {
+			tz := tzData.(map[string]interface{})
+			transportZones[i] = installer.TransportZone{
+				TransportType: tz["transport_type"].(string),
+			}
+			if name, ok := tz["name"].(string); ok && name != "" {
+				transportZones[i].Name = utils.ToStringPointer(name)
+			}
+		}
+		config.TransportZones = transportZones
+		hasConfig = true
+	}
+
+	if !hasConfig {
+		return nil
+	}
+
+	return config
 }

--- a/internal/sddc/sddc_vsan_subresource.go
+++ b/internal/sddc/sddc_vsan_subresource.go
@@ -6,6 +6,7 @@ package sddc
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	utils "github.com/vmware/terraform-provider-vcf/internal/resource_utils"
 	"github.com/vmware/vcf-sdk-go/installer"
 )
 
@@ -31,6 +32,11 @@ func GetVsanSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Enable vSAN ESA",
 				},
+				"failures_to_tolerate": {
+					Type:        schema.TypeInt,
+					Description: "Host failures to tolerate",
+					Optional:    true,
+				},
 			},
 		},
 	}
@@ -49,6 +55,11 @@ func GetVsanSpecFromSchema(rawData []interface{}) *installer.VsanSpec {
 		DatastoreName: &datastoreName,
 		VsanDedup:     &vsanDedup,
 		EsaConfig:     &installer.VsanEsaConfig{Enabled: &esaEnabled},
+	}
+
+	// Add failures_to_tolerate if provided
+	if failuresToTolerate, ok := data["failures_to_tolerate"].(int); ok {
+		vsanSpecBinding.FailuresToTolerate = utils.ToInt32Pointer(failuresToTolerate)
 	}
 
 	return vsanSpecBinding


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Add missed parameters for vcf_instance resource

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #335

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
