### PR TITLE
fix: update values for `appliance_size`

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -355,7 +355,7 @@ Required:
 
 Optional:
 
-- `appliance_size` (String) Appliance size
+- `appliance_size` (String)  Appliance size. One among: small or standard.
 - `root_user_password` (String, Sensitive) root password
 
 

--- a/internal/provider/resource_vcf_instance_test.go
+++ b/internal/provider/resource_vcf_instance_test.go
@@ -69,7 +69,7 @@ func testAccCheckVcfSddcConfigBasic() string {
 	  skip_esx_thumbprint_validation = true
 	  management_pool_name = "bringup-networkpool"
 	  ceip_enabled = false
-	  version = "5.2.0"
+	  version = "9.0.0"
 	  sddc_manager {
 		hostname = "sddc-manager"
 		ssh_password = "MnogoSl0jn@P@rol@!"
@@ -280,7 +280,7 @@ func TestVcfInstanceSchemaParse(t *testing.T) {
 		"instance_id":                    "sddcId-1001",
 		"skip_esx_thumbprint_validation": true,
 		"ceip_enabled":                   false,
-		"version":                        "5.2.0",
+		"version":                        "9.0.0",
 		"sddc_manager": []interface{}{
 			map[string]interface{}{
 				"hostname":            "sddc-manager",
@@ -487,7 +487,7 @@ func TestVcfInstanceSchemaParse(t *testing.T) {
 		"operations_collector": []interface{}{
 			map[string]interface{}{
 				"hostname":           "operations-1",
-				"appliance_size":     "medium",
+				"appliance_size":     "small",
 				"root_user_password": "MnogoSl0jn@P@rol@!",
 			},
 		},
@@ -560,11 +560,11 @@ func TestVcfInstanceSchemaParse(t *testing.T) {
 	assert.Equal(t, "operations-1", sddcSpec.VcfOperationsSpec.Nodes[0].Hostname)
 	assert.Equal(t, "operations-1", sddcSpec.VcfOperationsCollectorSpec.Hostname)
 	assert.Equal(t, utils.ToPointer[string]("MnogoSl0jn@P@rol@!"), (*sddcSpec.VcfOperationsCollectorSpec).RootUserPassword)
-	assert.Equal(t, utils.ToPointer[string]("medium"), (*sddcSpec.VcfOperationsCollectorSpec).ApplianceSize)
+	assert.Equal(t, utils.ToPointer[string]("small"), (*sddcSpec.VcfOperationsCollectorSpec).ApplianceSize)
 	assert.Equal(t, "operations-1", sddcSpec.VcfOperationsFleetManagementSpec.Hostname)
 	assert.Equal(t, utils.ToPointer[string]("MnogoSl0jn@P@rol@!"), (*sddcSpec.VcfOperationsFleetManagementSpec).RootUserPassword)
 	assert.Equal(t, utils.ToPointer[string]("MnogoSl0jn@P@rol@!"), (*sddcSpec.VcfOperationsFleetManagementSpec).AdminUserPassword)
-	assert.Equal(t, utils.ToStringPointer("5.2.0"), sddcSpec.Version)
+	assert.Equal(t, utils.ToStringPointer("9.0.0"), sddcSpec.Version)
 	assert.Equal(t, utils.ToPointer[int32](int32(1)), sddcSpec.DatastoreSpec.VsanSpec.FailuresToTolerate)
 	assert.Equal(t, "LOADBALANCE_SRCID", (*(*sddcSpec.DvsSpecs)[0].NsxTeamings)[0].Policy)
 	assert.Equal(t, utils.ToStringPointer("ENS_INTERRUPT"), (*sddcSpec.DvsSpecs)[0].NsxtSwitchConfig.HostSwitchOperationalMode)

--- a/internal/sddc/sddc_vcf_operations_collector_subresource.go
+++ b/internal/sddc/sddc_vcf_operations_collector_subresource.go
@@ -33,7 +33,7 @@ func GetVcfOperationsCollectorSchema() *schema.Schema {
 					Type:         schema.TypeString,
 					Description:  "Appliance size",
 					Optional:     true,
-					ValidateFunc: validation.StringInSlice([]string{"xsmall", "small", "medium", "large", "xlarge"}, true),
+					ValidateFunc: validation.StringInSlice([]string{"small", "standard"}, true),
 				},
 			},
 		},


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vcf/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Updated values for `appliance_size` in `GetVcfOperationsCollectorSchema` to use those from `cfOperationsCollectorSpec`.

Ref: https://developer.broadcom.com/xapis/vcf-installer-api/9.0/data-structures/VcfOperationsCollectorSpec/index.html?scrollString=vcfOperationsCollectorSpec

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
